### PR TITLE
fix: 修复MCPTool类解析警告

### DIFF
--- a/src/main/java/com/thoughtcoding/mcp/model/MCPTool.java
+++ b/src/main/java/com/thoughtcoding/mcp/model/MCPTool.java
@@ -1,5 +1,6 @@
 package com.thoughtcoding.mcp.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
@@ -7,6 +8,7 @@ import lombok.Data;
  * MCP工具模型，包含名称、描述和输入模式
  */
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MCPTool {
     @JsonProperty("name")
     private String name;


### PR DESCRIPTION
### 变更类型
- [x] 问题修复 (bug fix)

### 相关Issue
Closes #3

### 变更内容
本次PR专门修复启动时出现的"解析MCP工具失败"警告。具体修改：

**修改 `MCPTool.java` 类：**
- 添加 `@JsonIgnoreProperties(ignoreUnknown = true)` 注解到类声明上方
- 此注解允许Jackson在反序列化时忽略未知字段，解决字段不匹配警告

**修改位置：**
```java
// 修复前
@Data
public class MCPTool {
    // ... 字段定义
}

// 修复后
@Data
@JsonIgnoreProperties(ignoreUnknown = true)  // 新增注解
public class MCPTool {
    // ... 字段定义
}
```
### 变更原因
- **问题现象**：启动时出现警告"解析MCP工具失败"，提示MCPTool类缺失title、outputSchema、annotations、execution四个字段
- **根本原因**：MCP服务端返回的JSON包含的字段比本地类定义的字段多，Jackson严格模式导致解析警告
- **解决方案**：添加`@JsonIgnoreProperties(ignoreUnknown = true)`注解，优雅地处理未知字段

### 测试说明
**验证步骤：**
1. 拉取本分支代码
2. 重新启动应用
3. 观察启动日志

**预期结果：**
- ✅ 不再出现"解析MCP工具失败"相关警告
- ✅ MCP工具功能正常可用

**实际测试结果：**
已本地验证，警告消失，MCP工具调用正常。

### 其他注意事项
1. **向后兼容**：此修改不影响现有功能，仅改变Jackson的解析行为
2. **依赖要求**：需要Jackson库支持此注解（项目已包含）
3. **推荐原因**：相比添加四个可能不使用的字段，注解方案更简洁且能适应未来字段变化
