### PR TITLE
fix:AI无法感知预定义的MCP工具

### DIFF
--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -202,6 +202,12 @@ public class ThoughtCodingContext {
         try {
             var toolNames = java.util.Arrays.asList(toolsList.split(","));
             var tools = mcpToolManager.connectPredefinedTools(toolNames);
+            if (!tools.isEmpty()) {
+                // 注册工具（静默）
+                for (var tool : tools) {
+                    toolRegistry.register(tool);
+                }
+            }
             System.out.println("✓ 已连接 " + tools.size() + " 个预定义 MCP 工具");
             return !tools.isEmpty();
         } catch (Exception e) {


### PR DESCRIPTION
### 变更类型
- [x] 问题修复 (bug fix)

### 相关Issue
Closes #6


### 变更内容
本次PR专门修复使用CLI时"AI无法使用/感知预定义的MCP工具"bug。具体修改:
修改 `usePredefinedMCPTools` 方法：
- 添加工具注册逻辑：连接成功后自动注册到工具管理器

**修改位置：**
```java
public boolean usePredefinedMCPTools(String toolsList) {
    // ... 原有连接逻辑
    
    // 新增：工具注册（静默）
    for (var tool : tools) {
        toolRegistry.register(tool);  // 关键新增
    }
    
    // ... 后续逻辑
}
```

### 变更原因
- 问题现象：预定义MCP工具连接成功但无法使用，AI调用时提示"工具未找到"
- 根本原因：usePredefinedMCPTools 方法仅连接工具，未将工具注册到系统
- 解决方案：在连接成功后添加 toolRegistry.register(tool) 调用，确保工具被正确注册

### 测试说明
**验证步骤：**
1. 拉取本分支代码
2. 重新启动应用
3. 在交互模式下使用/mcp tools ... 类命令 或 使用--mcp-tools参数命令
4. 让ai调用步骤三创建的工具以验证

**实际测试结果：**
已本地验证，预定义MCP工具连接后能正确注册并被AI调用。

<img width="1273" height="697" alt="截屏2026-01-31 19 44 48" src="https://github.com/user-attachments/assets/b3ef3b15-2a86-4d0e-92ea-5f8f6c7089c8" />
<img width="1205" height="606" alt="截屏2026-01-31 19 45 01" src="https://github.com/user-attachments/assets/a482a43a-0d9d-4a76-a1b4-51cf414b9dfe" />