### PR TITLE
fix:AI无法感知动态连接的MCP工具 

### DIFF
--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -178,6 +178,10 @@ public class ThoughtCodingContext {
             // 🔥 直接传递三个参数，不再创建 Map
             var tools = mcpService.connectToServer(serverName, command, args);
             if (!tools.isEmpty()) {
+                // 注册工具（静默）
+                for (var tool : tools) {
+                    toolRegistry.register(tool);
+                }
                 System.out.println("✓ 成功连接 MCP 服务器: " + serverName +
                         " (" + tools.size() + " 个工具)");
                 return true;


### PR DESCRIPTION
### 变更类型
- [x] 问题修复 (bug fix)

### 相关Issue
Closes #7


### 变更内容
本次PR专门修复使用CLI时"AI无法使用/感知动态连接的MCP工具"bug。具体修改:
修改 `connectMCPServer` 方法：
- 添加工具注册逻辑：连接成功后自动注册到工具管理器

**修改位置：**
```java
public boolean connectMCPServer(String serverName, String command, List<String> args) {
    // ... 原有逻辑
    
    // 新增：工具注册（静默）
    for (var tool : tools) {
        toolRegistry.register(tool);  // 关键新增
    }
    
    // ... 后续逻辑
}
```

### 变更原因
- 问题现象：预定义MCP工具连接成功但无法使用，AI调用时提示"工具未找到"
- 根本原因：connectMCPServer 方法仅连接工具，未将工具注册到系统
- 解决方案：在连接成功后添加 toolRegistry.register(tool) 调用，确保工具被正确注册

### 测试说明
**验证步骤：**
1. 拉取本分支代码
2. 重新启动应用
3. 在交互模式下使用/mcp connect ... 类命令
4. 让ai调用步骤三创建的工具以验证

**实际测试结果：**
已本地验证，预定义MCP工具连接后能正确注册并被AI调用。

<img width="607" height="690" alt="截屏2026-01-31 19 55 52" src="https://github.com/user-attachments/assets/a5d892f3-ac06-4573-a150-878e4b7c03a3" />