### PR TITLE
fix: 修复ChatRenderer时间戳格式化错误

### DIFF
--- a/src/main/java/com/thoughtcoding/ui/component/ChatRenderer.java
+++ b/src/main/java/com/thoughtcoding/ui/component/ChatRenderer.java
@@ -4,6 +4,8 @@ import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.ui.AnsiColors;
 import org.jline.terminal.Terminal;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -20,7 +22,7 @@ public class ChatRenderer {
     }
 
     public void renderUserMessage(ChatMessage message) {
-        String timestamp = String.format(String.valueOf(timeFormatter));
+        String timestamp = LocalDateTime.now().format(timeFormatter);
         String formattedMessage = String.format("%s[%s] %sYou:%s %s",
                 AnsiColors.BRIGHT_BLACK, timestamp, AnsiColors.BRIGHT_BLUE, AnsiColors.RESET, message.getContent());
 


### PR DESCRIPTION
### 变更类型
- [x] 问题修复 (bug fix)

### 相关Issue
Closes #13 


### 变更内容
本次PR专门修复使用CLI时"ChatRenderer时间戳格式化错误"bug。具体修改:
修改 `renderUserMessage` 方法：
- 修改timestamp为使用时间格式的当前时间

**修改位置：**
```java
    public void renderUserMessage(ChatMessage message) {
        String timestamp = LocalDateTime.now().format(timeFormatter);
        // ... 后续逻辑
    }
```

### 变更原因
- 问题现象：单次对话模式下，用户消息回显时间戳部分异常
- 根本原因：timestamp被赋为一个时间格式字符串
- 解决方案：将timestamp赋为使用时间格式的当前时间

### 测试说明
**验证步骤：**
1. 拉取本分支代码
2. 重新启动应用
3. 发起单次对话
4. 观察用户消息时间戳部分回显

**实际测试结果：**
已本地验证，时间戳能正常显示
<img width="277" height="68" alt="截屏2026-02-06 22 58 59" src="https://github.com/user-attachments/assets/b41a255d-498a-458c-a4c6-6c1949a666bf" />