### PR TITLE
聊天消息类型加入角色tool

### DIFF
--- a/src/main/java/com/thoughtcoding/model/ChatMessage.java
+++ b/src/main/java/com/thoughtcoding/model/ChatMessage.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Data
 public class ChatMessage {
     private final String id;
-    private final String role; // "user", "assistant", "system"
+    private final String role; // "user", "assistant", "system", "tool"
     private final String content;
     private final String timestamp;
     private final String sessionId;
@@ -25,6 +25,9 @@ public class ChatMessage {
 
     @JsonIgnore
     private boolean assistantMessage;
+
+    @JsonIgnore
+    private boolean toolMessage;
     // 无参构造函数 - 需要提供默认值
     public ChatMessage() {
         this.role = "user";
@@ -79,6 +82,8 @@ public class ChatMessage {
     public boolean isSystemMessage() {
         return "system".equals(role);
     }
+
+    public boolean isToolMessage() { return "tool".equals(role); }
 
     public void setRole() {
         String role = "user";


### PR DESCRIPTION
<img width="964" height="691" alt="d03e4bef-a24d-4064-8688-7f5ffda4462c" src="https://github.com/user-attachments/assets/a60b90c8-9369-440b-92a5-e62316f211dd" />

LangChain4j框架已支持五种消息类型，此PR对ChatMessage做了最简单更新 **添加角色tool**，旨在未来更规范管理工具结果以及上下文