### PR TITLE
新的压缩上下文Token策略

### DIFF
--- a/src/main/java/com/thoughtcoding/model/ChatMessage.java
+++ b/src/main/java/com/thoughtcoding/model/ChatMessage.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 public class ChatMessage {
     private final String id;
     private final String role; // "user", "assistant", "system"
-    private final String content;
+    private String content; //压缩工具结果需要其为变量
     private final String timestamp;
     private final String sessionId;
     @JsonIgnore  // 忽略这些字段的序列化
@@ -86,6 +86,10 @@ public class ChatMessage {
 
     public void setContent() {
         String content = "";
+    }
+
+    public void setContent(String content) {
+        this.content = content;
     }
 
     public void setTimestamp(String s) {

--- a/src/main/java/com/thoughtcoding/model/ChatMessage.java
+++ b/src/main/java/com/thoughtcoding/model/ChatMessage.java
@@ -51,6 +51,15 @@ public class ChatMessage {
         this.sessionId = sessionId;
     }
 
+    //深拷贝构造器
+    public ChatMessage(ChatMessage other) {
+        this.id = other.id;
+        this.role = other.role;
+        this.content = other.content;
+        this.timestamp = other.timestamp;
+        this.sessionId = other.sessionId;
+    }
+
     // 添加静态工厂方法
     public static ChatMessage from(String content) {
         return new ChatMessage("assistant", content); // 默认角色为 "assistant"

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -25,6 +25,7 @@ public class ContextManager {
     private static final int DEFAULT_MAX_HISTORY_TURNS = 10;  // 保留10轮（20条消息）
     private static final int DEFAULT_MAX_CONTEXT_TOKENS = 3000;  // 为历史预留3000 tokens
     private static final int DEFAULT_RESERVE_TOKENS = 1000;  // 为响应预留1000 tokens
+    private static final int DEFAULT_KEEP_RECENT = 3;
 
     // 策略枚举
     public enum Strategy {
@@ -64,6 +65,8 @@ public class ContextManager {
         }
 
         List<ChatMessage> result;
+
+        micro_compact(fullHistory);
 
         switch (strategy) {
             case SLIDING_WINDOW:
@@ -289,6 +292,64 @@ public class ContextManager {
         } catch (Exception e) {
             log.warn("无法构建项目上下文: {}", e.getMessage());
             return null;
+        }
+    }
+
+    private void micro_compact(List<ChatMessage> messages) {
+        List<ChatMessage> toolResults = new ArrayList<>();
+        for(ChatMessage msg  : messages) {
+            if(msg != null && msg.getRole().equals("system") && isToolResultMessage(msg.getContent())) {
+                toolResults .add(msg);
+            }
+        }
+
+        int KEEP_RECENT = DEFAULT_KEEP_RECENT;
+        if(toolResults.size() <= KEEP_RECENT){
+            return;
+        }
+
+        // 需要压缩的早期消息（除了最后 KEEP_RECENT 条）
+        List<ChatMessage> toCompact = toolResults.subList(0, toolResults.size() - KEEP_RECENT);
+
+        for(ChatMessage msg : toCompact){
+            String content = msg.getContent();
+            // 如果内容较长（超过100字符），则压缩为摘要
+            if(content != null && content.length() > 100) {
+                String toolName = extractToolNameFromContent(content);
+                String summary = String.format("[Previous: used %s]", toolName);
+                msg.setContent(summary);
+            }
+        }
+    }
+
+    private boolean isToolResultMessage(String content) {
+        if (content == null) return false;
+        // 工具成功或失败消息的特征前缀
+        return content.startsWith("Tool '") || content.startsWith("Tool execution failed: ");
+    }
+
+    // 从消息内容中提取工具名称
+    // 格式示例: "Tool 'read_file' executed successfully ..." 或 "Tool execution failed: 'unknown_tool' not found."
+    private String extractToolNameFromContent(String content) {
+        try {
+            // 查找单引号之间的内容
+            int start = content.indexOf('\'');
+            int end = content.indexOf('\'', start + 1);
+            if (start != -1 && end != -1) {
+                return content.substring(start + 1, end);
+            }
+            // 降级处理：尝试匹配 "Tool execution failed: " 后的内容
+            if (content.startsWith("Tool execution failed: ")) {
+                String after = content.substring("Tool execution failed: ".length());
+                int space = after.indexOf(' ');
+                if (space > 0) {
+                    return after.substring(0, space);
+                }
+                return "unknown";
+            }
+            return "unknown";
+        } catch (Exception e) {
+            return "unknown";
         }
     }
 

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -66,20 +66,21 @@ public class ContextManager {
 
         List<ChatMessage> result;
 
-        micro_compact(fullHistory);
+        //自动压缩超过三轮的工具调用结果
+        List<ChatMessage> afterMicro = micro_compact(fullHistory);
 
         switch (strategy) {
             case SLIDING_WINDOW:
-                result = applySlidingWindow(fullHistory);
+                result = applySlidingWindow(afterMicro);
                 break;
             case TOKEN_BASED:
-                result = applyTokenLimit(fullHistory);
+                result = applyTokenLimit(afterMicro);
                 break;
             case HYBRID:
-                result = applyHybridStrategy(fullHistory);
+                result = applyHybridStrategy(afterMicro);
                 break;
             default:
-                result = fullHistory;
+                result = afterMicro;
         }
 
         // 输出统计信息
@@ -295,31 +296,38 @@ public class ContextManager {
         }
     }
 
-    private void micro_compact(List<ChatMessage> messages) {
+    private List<ChatMessage> micro_compact(List<ChatMessage> messages) {
+        // sessions中保存结果不变，不可修改messages，使用深拷贝：创建全新消息对象
+        List<ChatMessage> result = new ArrayList<>();
+        for (ChatMessage msg : messages) {
+            result.add(new ChatMessage(msg)); // 使用复制构造器
+        }
+
+        // 收集工具结果消息（在 result 中）
         List<ChatMessage> toolResults = new ArrayList<>();
-        for(ChatMessage msg  : messages) {
-            if(msg != null && msg.getRole().equals("system") && isToolResultMessage(msg.getContent())) {
-                toolResults .add(msg);
+        for (ChatMessage msg : result) {
+            if (msg != null && msg.getRole().equals("system") && isToolResultMessage(msg.getContent())) {
+                toolResults.add(msg);
             }
         }
 
         int KEEP_RECENT = DEFAULT_KEEP_RECENT;
-        if(toolResults.size() <= KEEP_RECENT){
-            return;
+        if (toolResults.size() <= KEEP_RECENT) {
+            return result; // 不需要压缩，返回深拷贝副本
         }
 
-        // 需要压缩的早期消息（除了最后 KEEP_RECENT 条）
+        // 压缩早期的工具结果（除了最后 KEEP_RECENT 条）
         List<ChatMessage> toCompact = toolResults.subList(0, toolResults.size() - KEEP_RECENT);
-
-        for(ChatMessage msg : toCompact){
+        for (ChatMessage msg : toCompact) {
             String content = msg.getContent();
-            // 如果内容较长（超过100字符），则压缩为摘要
-            if(content != null && content.length() > 100) {
+            if (content != null && content.length() > 100) {
                 String toolName = extractToolNameFromContent(content);
                 String summary = String.format("[Previous: used %s]", toolName);
                 msg.setContent(summary);
             }
         }
+
+        return result;
     }
 
     private boolean isToolResultMessage(String content) {

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -25,7 +25,7 @@ public class ContextManager {
     private static final int DEFAULT_MAX_HISTORY_TURNS = 10;  // 保留10轮（20条消息）
     private static final int DEFAULT_MAX_CONTEXT_TOKENS = 3000;  // 为历史预留3000 tokens
     private static final int DEFAULT_RESERVE_TOKENS = 1000;  // 为响应预留1000 tokens
-    private static final int DEFAULT_KEEP_RECENT = 3;
+    private static final int DEFAULT_KEEP_RECENT = 3; // 保留3轮（三轮以上的tool_result将被清除）
 
     // 策略枚举
     public enum Strategy {


### PR DESCRIPTION
### 随着tool的调用，tool_result会慢慢叠加，直至上下文token爆炸!

应对此问题，此PR完善了新的压缩Token策略：对于超过`DEFAULT_KEEP_RECENT`轮以上的历史`tool_result`，将其调用结果(content)设为`String summary = String.format("[Previous: used %s]", toolName);`

此策略源自Claude Code的压缩上下文思想 [https://learn.shareai.run/zh/s06/](url)