### PR TITLE
Feature/权限分支

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,32 +560,32 @@ cd ThoughtCoding
 继承 `BaseTool` 基类并实现核心方法：
 
 ```java
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 public class MyTool extends BaseTool {
-    
+
     public MyTool() {
         super("my_tool", "工具描述");
     }
-    
+
     @Override
     public ToolResult execute(String input) {
         // input 为 JSON 字符串，从 ToolDispatcher 传入
         // 工具实现逻辑
         return success("工具执行结果");
     }
-    
+
     @Override
     public JsonObjectSchema inputSchema() {
         // 定义工具参数 schema（供模型了解参数结构）
         return JsonObjectSchema.builder()
-            .addStringProperty("param1", "参数1描述")
-            .build();
+                .addStringProperty("param1", "参数1描述")
+                .build();
     }
-    
+
     @Override
     public boolean isReadOnly() {
         // 只读工具返回 true，静默放行无需用户确认

--- a/src/main/java/com/thoughtcoding/cli/MCPCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/MCPCommand.java
@@ -2,8 +2,7 @@ package com.thoughtcoding.cli;
 
 import com.thoughtcoding.mcp.MCPService;
 import com.thoughtcoding.mcp.MCPToolManager;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 

--- a/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
@@ -301,6 +301,7 @@ public class ThoughtCodingCommand implements Callable<Integer> {
                 }
 
                 // 🚀 新增：检查是否是直接命令执行
+                //TODO ：优化正则检测，降低误判率
                 if (directCommandExecutor.shouldExecuteDirectly(trimmedInput)) {
                     directCommandExecutor.executeDirectCommand(trimmedInput);
                     continue;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,8 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tools.BaseTool;
-import com.thoughtcoding.tools.ToolDispatcher;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -96,6 +96,9 @@ public class AgentLoop {
             pendingToolCalls.clear();
             // 一轮模型响应（无新用户输入；用户消息与历史已在 history 中）
             context.getAiService().streamingChat(null, history, modelName);
+            // 空一行，避免与后续工具确认/结果挤在一起
+            context.getUi().getTerminal().writer().println();
+            context.getUi().getTerminal().flush();
 
             if (pendingToolCalls.isEmpty()) {
                 break; // 模型只产出文本 → 自然终止
@@ -132,6 +135,8 @@ public class AgentLoop {
                 // 执行并把结果按 id 配对写回 history
                 ToolResult result = toolDispatcher.dispatch(call);
                 displayNativeToolResult(call, result);
+                // 工具结果显示后空一行，避免与下一轮 AI 流式文本挤在同一区域
+                context.getUi().getTerminal().writer().println();
                 String resultText = result.isSuccess()
                         ? (result.getOutput() == null || result.getOutput().isBlank()
                             ? "执行成功（无输出）。" : result.getOutput())

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -25,7 +25,7 @@ public class AgentLoop {
     private final String sessionId;
     private final String modelName;
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
-    private final ToolDispatcher toolDispatcher;           // 工具执行唯一收口（沙箱插桩点）
+    private final ToolDispatcher toolDispatcher;
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,7 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.PermissionGate;
+import com.thoughtcoding.tool.PermissionResult;
 import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ import java.util.List;
  * AI 交互的核心循环。
  *
  * 基于 langchain4j 原生 function calling 的多轮 agentic 循环：
- * 用户输入 → 模型响应（可能请求工具）→ 执行工具（仅写/执行类确认）→ 结果按 id 配对回喂 →
+ * 用户输入 → 模型响应（可能请求工具）→ 权限检查 → 执行工具（写/执行类 + 越界只读类确认）→ 结果按 id 配对回喂 →
  * 无新输入再问模型，直到模型不再请求工具、用户取消、或达到 maxToolIterations。
  */
 public class AgentLoop {
@@ -115,8 +116,19 @@ public class AgentLoop {
                     continue;
                 }
 
-                // 仅写/执行类需要确认（除非处于自动批准模式）
-                if (requiresConfirmation(call) && !confirmation.isAutoApproveMode()) {
+                // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
+                PermissionResult perm = PermissionGate.check(
+                    call.getToolName(), call.getParameters());
+
+                if (perm.type() == PermissionResult.Type.DENY) {
+                    context.getUi().displayError(perm.message());
+                    history.add(ChatMessage.toolResult(
+                        call.getProviderCallId(), call.getToolName(), perm.message()));
+                    continue;
+                }
+
+                if (perm.type() == PermissionResult.Type.WARN
+                    && !confirmation.isAutoApproveMode()) {
                     ToolExecution exec = new ToolExecution(
                             call.getToolName(),
                             call.getDescription() != null ? call.getDescription() : "执行工具操作",
@@ -157,17 +169,6 @@ public class AgentLoop {
                 break;
             }
         }
-    }
-
-    /** 写/执行类工具需要确认；只读工具（由工具自身 isReadOnly() 声明）静默放行。 */
-    private boolean requiresConfirmation(ToolCall call) {
-        String name = call.getToolName();
-        if (name == null) {
-            return true;
-        }
-        BaseTool tool = context.getToolRegistry().getTool(name);
-        // 未知/MCP 工具（未声明只读）默认需确认；工具自身声明 isReadOnly 则静默放行。
-        return tool == null || !tool.isReadOnly();
     }
 
     private String describeTool(ToolCall call) {

--- a/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
+++ b/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
@@ -1,6 +1,6 @@
 package com.thoughtcoding.core;
 
-import com.thoughtcoding.tools.BashTool;
+import com.thoughtcoding.tool.tools.BashTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 import com.thoughtcoding.model.ToolResult;
 

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -10,12 +10,13 @@ import com.thoughtcoding.service.ContextManager;
 import com.thoughtcoding.service.LangChainService;
 import com.thoughtcoding.service.PerformanceMonitor;
 import com.thoughtcoding.service.SessionService;
-import com.thoughtcoding.tools.*;
-import com.thoughtcoding.tools.BashTool;
-import com.thoughtcoding.tools.EditTool;
-import com.thoughtcoding.tools.ReadTool;
-import com.thoughtcoding.tools.WriteTool;
-import com.thoughtcoding.tools.GlobTool;
+import com.thoughtcoding.tool.*;
+import com.thoughtcoding.tool.tools.BashTool;
+import com.thoughtcoding.tool.tools.EditTool;
+import com.thoughtcoding.tool.tools.GlobTool;
+import com.thoughtcoding.tool.tools.ReadTool;
+import com.thoughtcoding.tool.Sandbox;
+import com.thoughtcoding.tool.tools.WriteTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 
 import java.util.ArrayList;
@@ -67,6 +68,9 @@ public class ThoughtCodingContext {
         configManager.initialize("config.yaml");
         AppConfig appConfig = configManager.getAppConfig();
         MCPConfig mcpConfig = configManager.getMCPConfig();
+
+        // 初始化沙箱（以启动时的工作目录为 workspace 根）
+        Sandbox.init(System.getProperty("user.dir"));
 
         // 能力层初始化,创建工具注册表
         ToolRegistry toolRegistry = new ToolRegistry(appConfig);

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,10 +1,9 @@
 package com.thoughtcoding.exception;
 
 /**
- * 沙箱路径越界异常。
+ * 沙箱路径异常。
  *
- * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
- * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ * 由 {@link com.thoughtcoding.tool.Sandbox#resolve} 在路径为空白时抛出。
  */
 public class WorkspaceSecurityException extends RuntimeException {
 

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,0 +1,14 @@
+package com.thoughtcoding.exception;
+
+/**
+ * 沙箱路径越界异常。
+ *
+ * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
+ * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ */
+public class WorkspaceSecurityException extends RuntimeException {
+
+    public WorkspaceSecurityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/thoughtcoding/mcp/MCPService.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPService.java
@@ -3,8 +3,7 @@ package com.thoughtcoding.mcp;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.mcp.model.MCPTool;
 import com.thoughtcoding.model.ToolResult;
-import com.thoughtcoding.tools.BaseTool; // 使用你的 BaseTool 基类
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool; // 使用你的 BaseTool 基类
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
@@ -1,9 +1,7 @@
 package com.thoughtcoding.mcp;
 
 import com.thoughtcoding.config.MCPConfig;
-import com.thoughtcoding.config.MCPServerConfig;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -171,7 +171,6 @@ public class LangChainService implements AIService {
                             history.add(new ChatMessage("assistant", text));
                         }
                     }
-                    System.out.println();
                 } finally {
                     isGenerating = false;
                     shouldStop = false;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -4,7 +4,7 @@ import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolCallRef;
-import com.thoughtcoding.tools.ToolRegistry;
+import com.thoughtcoding.tool.ToolRegistry;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;

--- a/src/main/java/com/thoughtcoding/tool/BaseTool.java
+++ b/src/main/java/com/thoughtcoding/tool/BaseTool.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,0 +1,122 @@
+package com.thoughtcoding.tool;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 权限管道 —— AgentLoop 的唯一决策入口。
+ *
+ * <pre>
+ * 调用方式：
+ *   PermissionResult perm = PermissionGate.check(toolName, params);
+ *   if (perm.type() == DENY)  → 直接报错跳过
+ *   if (perm.type() == WARN)  → 弹确认
+ *   // ALLOW → 静默放行
+ * </pre>
+ *
+ * 决策规则：
+ *   read / glob  → 路径越界则 WARN，否则 ALLOW
+ *   write / edit → 固定 WARN
+ *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
+ *   未知工具      → WARN
+ */
+public final class PermissionGate {
+
+    private PermissionGate() {}
+
+    // ═══════════════ Gate 1: 硬拒绝列表 ═══════════════
+
+    private static final List<String> BASH_DENY_PATTERNS = List.of(
+        "rm -rf /", "sudo ", "shutdown", "reboot", "mkfs",
+        "dd if=", "> /dev/sda", "format ", "del /f /s", "rd /s /q"
+    );
+
+    private static PermissionResult checkBashDeny(String command) {
+        if (command == null || command.isBlank()) return null;
+        String lower = command.toLowerCase();
+        for (String pattern : BASH_DENY_PATTERNS) {
+            if (lower.contains(pattern)) {
+                return PermissionResult.deny(
+                    "⛔ 命令被阻止: '" + pattern + "' 在拒绝列表中");
+            }
+        }
+        return null;
+    }
+
+    // ═══════════════ Gate 2: 规则匹配 ═══════════════
+
+    // ── read / glob：路径越界才确认 ──
+    private static PermissionResult checkReadPath(Map<String, Object> params) {
+        String pathStr = paramString(params, "path");
+        if (pathStr == null || pathStr.isBlank()) return PermissionResult.ALLOW;
+
+        try {
+            Path resolved = Sandbox.resolve(pathStr);
+            if (!Sandbox.isWithinWorkspace(resolved)) {
+                return PermissionResult.warn(
+                    "⚠️ 路径在 workspace 之外: " + resolved);
+            }
+        } catch (Exception ignored) {
+            // 解析失败不报 warning
+        }
+        return PermissionResult.ALLOW;
+    }
+
+    // ── bash：先过 Gate 1 拒绝列表，再追加危险模式提示 ──
+    private static PermissionResult checkBash(Map<String, Object> params) {
+        String command = paramString(params, "command");
+
+        // Gate 1: 硬拒绝
+        PermissionResult deny = checkBashDeny(command);
+        if (deny != null) return deny;
+
+        // 固定确认，有危险模式则追加提示
+        String extra = bashWarning(command);
+        return PermissionResult.warn(
+            "⚠️ 将执行 shell 命令" + (extra.isEmpty() ? "" : " —— " + extra));
+    }
+
+    /** 返回危险模式描述，无匹配返回空串。 */
+    private static String bashWarning(String command) {
+        if (command == null || command.isBlank()) return "";
+        String lower = command.toLowerCase();
+
+        if (lower.contains("rm ") || lower.contains("del "))
+            return "包含删除操作";
+        if (lower.contains("> /etc/") || lower.contains("> c:\\windows"))
+            return "写入系统目录";
+        if (lower.contains("chmod 777"))
+            return "修改关键权限";
+        if (lower.contains("git push --force") || lower.contains("git push -f"))
+            return "强制推送";
+        return "";
+    }
+
+    // ═══════════════ 入口 ═══════════════
+
+    /**
+     * 一次性权限决策。
+     *
+     * @return DENY → 拒绝执行；WARN → 弹确认；ALLOW → 静默放行
+     */
+    public static PermissionResult check(String toolName, Map<String, Object> params) {
+        if (toolName == null) return PermissionResult.warn("⚠️ 未知工具");
+
+        return switch (toolName) {
+            case "read", "glob" -> checkReadPath(params);
+            case "write"        -> PermissionResult.warn("⚠️ 将写入文件");
+            case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
+            case "bash"         -> checkBash(params);
+            default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
+        };
+    }
+
+    // ── 工具方法 ──
+
+    private static String paramString(Map<String, Object> params, String key) {
+        if (params == null) return null;
+        Object v = params.get(key);
+        return v == null ? null : v.toString();
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,5 +1,7 @@
 package com.thoughtcoding.tool;
 
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +59,9 @@ public final class PermissionGate {
                 return PermissionResult.warn(
                     "⚠️ 路径在 workspace 之外: " + resolved);
             }
-        } catch (Exception ignored) {
-            // 解析失败不报 warning
+        } catch (WorkspaceSecurityException e) {
+            // 路径为空/非法 → 交给工具侧报具体错误，权限不做拦截
+            return PermissionResult.ALLOW;
         }
         return PermissionResult.ALLOW;
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionResult.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionResult.java
@@ -1,0 +1,25 @@
+package com.thoughtcoding.tool;
+
+/**
+ * 权限检查结果。
+ *
+ * <pre>
+ *   deny  → 硬拒绝，不弹确认，直接报错
+ *   warn  → 命中规则，强制弹确认（即使只读工具也不例外）
+ *   allow → 正常走确认流程（该确认的工具会确认，只读工具静默放行）
+ * </pre>
+ */
+public record PermissionResult(Type type, String message) {
+
+    public enum Type { DENY, WARN, ALLOW }
+
+    public static PermissionResult deny(String message) {
+        return new PermissionResult(Type.DENY, message);
+    }
+
+    public static PermissionResult warn(String message) {
+        return new PermissionResult(Type.WARN, message);
+    }
+
+    public static final PermissionResult ALLOW = new PermissionResult(Type.ALLOW, null);
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -1,0 +1,114 @@
+package com.thoughtcoding.tool;
+
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ *
+ * <pre>
+ * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
+ * Path path = Sandbox.safePath(p.toString());
+ * </pre>
+ *
+ * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ */
+public final class Sandbox {
+
+    private static volatile Path workspaceRoot;
+
+    private Sandbox() {
+        // 工具类，禁止实例化
+    }
+
+    // ── 初始化 ──
+
+    /** 由 ThoughtCodingContext 初始化时调用一次。 */
+    public static void init(String workspacePath) {
+        Path raw = Paths.get(workspacePath).toAbsolutePath().normalize();
+        try {
+            workspaceRoot = raw.toRealPath();
+        } catch (Exception e) {
+            workspaceRoot = raw;
+        }
+    }
+
+    private static Path root() {
+        Path r = workspaceRoot;
+        if (r == null) {
+            // 未显式 init 时降级使用当前工作目录
+            r = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+            try {
+                r = r.toRealPath();
+            } catch (Exception ignored) {
+            }
+            workspaceRoot = r;
+        }
+        return r;
+    }
+
+    // ── 核心方法 ──
+
+    /**
+     * 校验并返回安全路径。
+     *
+     * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
+     * @return 已解析的绝对路径
+     * @throws WorkspaceSecurityException 路径在 workspace 之外
+     */
+    public static Path safePath(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            throw new WorkspaceSecurityException("路径不能为空");
+        }
+
+        Path root = root();
+        String expanded = expandUserHome(rawPath.trim());
+        Path target = root.resolve(expanded).normalize();
+
+        try {
+            Path real = target.toRealPath();
+            if (!real.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
+            }
+            return real;
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception fileNotExist) {
+            return validateParent(rawPath, target, root);
+        }
+    }
+
+    /** 文件不存在时，退而校验父目录。 */
+    private static Path validateParent(String rawPath, Path target, Path root) {
+        Path parent = target.getParent();
+        if (parent == null) {
+            throw new WorkspaceSecurityException(
+                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
+        }
+        try {
+            Path realParent = parent.toRealPath();
+            if (!realParent.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
+            }
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+        }
+        return target;
+    }
+
+    private static String expandUserHome(String path) {
+        if (path.equals("~")) {
+            return System.getProperty("user.home");
+        }
+        if (path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home") + path.substring(1);
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -6,14 +6,21 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ * 通用沙箱 —— 路径解析工具。
  *
  * <pre>
- * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
- * Path path = Sandbox.safePath(p.toString());
+ * // 工具内用法（只解析，不做权限决策）：
+ * Path path = Sandbox.resolve(p.toString());
+ *
+ * // PermissionGate 内用法（组合判断）：
+ * Path resolved = Sandbox.resolve(rawPath);
+ * if (!Sandbox.isWithinWorkspace(resolved)) {
+ *     return PermissionResult.warn("⚠️ 路径在 workspace 之外");
+ * }
  * </pre>
  *
- * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ * 权限决策由 PermissionGate 负责，AgentLoop 通过确认框交给用户选择，
+ * 默认 ask 而不是 deny。
  */
 public final class Sandbox {
 
@@ -49,57 +56,43 @@ public final class Sandbox {
         return r;
     }
 
-    // ── 核心方法 ──
+    // ── 路径解析（不做权限决策）──
 
     /**
-     * 校验并返回安全路径。
+     * 解析原始路径为绝对路径（展开 ~、相对于 workspace root 解析、normalize）。
+     * 不做越界检查——权限决策由上层 AgentLoop 负责。
      *
      * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
      * @return 已解析的绝对路径
-     * @throws WorkspaceSecurityException 路径在 workspace 之外
      */
-    public static Path safePath(String rawPath) {
+    public static Path resolve(String rawPath) {
         if (rawPath == null || rawPath.isBlank()) {
             throw new WorkspaceSecurityException("路径不能为空");
         }
 
         Path root = root();
         String expanded = expandUserHome(rawPath.trim());
-        Path target = root.resolve(expanded).normalize();
-
-        try {
-            Path real = target.toRealPath();
-            if (!real.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
-            }
-            return real;
-        } catch (WorkspaceSecurityException e) {
-            throw e;
-        } catch (Exception fileNotExist) {
-            return validateParent(rawPath, target, root);
-        }
+        return root.resolve(expanded).normalize();
     }
 
-    /** 文件不存在时，退而校验父目录。 */
-    private static Path validateParent(String rawPath, Path target, Path root) {
-        Path parent = target.getParent();
-        if (parent == null) {
-            throw new WorkspaceSecurityException(
-                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
-        }
+    /**
+     * 判断给定路径是否在 workspace 范围内。
+     */
+    public static boolean isWithinWorkspace(Path path) {
+        if (path == null) return false;
+        Path root = root();
         try {
-            Path realParent = parent.toRealPath();
-            if (!realParent.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
-            }
-        } catch (WorkspaceSecurityException e) {
-            throw e;
+            return path.toRealPath().startsWith(root);
         } catch (Exception e) {
-            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+            // 文件不存在时检查父目录
+            Path parent = path.getParent();
+            if (parent == null) return false;
+            try {
+                return parent.toRealPath().startsWith(root);
+            } catch (Exception ex) {
+                return false;
+            }
         }
-        return target;
     }
 
     private static String expandUserHome(String path) {

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.model.ToolCall;

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
- *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
+ * {@link #dispatch(ToolCall)}。权限检查由 AgentLoop 调用 {@link PermissionGate} 完成，
+ * 工具内部通过 {@link Sandbox#resolve} 只做路径解析，不做权限决策。
  */
 public class ToolDispatcher {
 
@@ -23,7 +23,7 @@ public class ToolDispatcher {
     }
 
     /**
-     * 执行一个工具调用：查表 → 序列化参数 →（沙箱检查）→ 执行。
+     * 执行一个工具调用：查表 → 序列化参数 → 执行。
      */
     public ToolResult dispatch(ToolCall call) {
         long start = System.currentTimeMillis();

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。这样未来的 workspace 沙箱只需在此一处插桩，即可以结构化的
- * (name, args) 看到 100% 的写/执行操作。
+ * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
+ *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
  */
 public class ToolDispatcher {
 
@@ -34,11 +34,6 @@ public class ToolDispatcher {
         }
 
         String argsJson = toJson(call.getParameters());
-
-        // 【沙箱插桩点】——下一任务在此插入 workspace 边界检查：
-        //   WriteGuard.check(call.getToolName(), call.getParameters())
-        // 对 write/edit 的 path、bash 的 command 做越界判定，
-        // 越界时直接 return ToolResult.error(...) 不进入 tool.execute。
 
         return tool.execute(argsJson);
     }

--- a/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.config.AppConfig;
 

--- a/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;

--- a/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.BufferedReader;
@@ -76,21 +77,31 @@ public class BashTool extends BaseTool {
 
             Process process = pb.start();
 
+            // 后台线程消费 stdout，避免主线程因 readLine 阻塞而无法触发超时
             StringBuilder output = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    output.append(line).append("\n");
+            Thread readerThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        output.append(line).append("\n");
+                    }
+                } catch (Exception ignored) {
+                    // 进程被 destroy 后流关闭，忽略
                 }
-            }
+            }, "bash-stdout-reader");
+            readerThread.start();
 
             boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
-                return error("命令超时（>" + timeoutSeconds + "s），已被终止:\n" + output.toString().trim(),
+                readerThread.interrupt();
+                return error("命令超时（>" + timeoutSeconds + "s），已被终止",
                         System.currentTimeMillis() - startTime);
             }
+
+            // 进程已退出，等 reader 线程收完最后几行输出
+            readerThread.join(5000);
 
             int exitCode = process.exitValue();
             String result = output.toString().trim();

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -84,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -56,7 +58,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -83,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -58,7 +57,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -85,8 +84,6 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
@@ -13,7 +14,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
+
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class GlobTool extends BaseTool {
             Object pathObj = params.get("path");
             String basePathStr = (pathObj == null || pathObj.toString().trim().isEmpty())
                     ? "." : pathObj.toString();
-            Path base = Paths.get(expandUserHome(basePathStr)).toAbsolutePath().normalize();
+            Path base = Sandbox.resolve(basePathStr);
 
             if (!Files.exists(base) || !Files.isDirectory(base)) {
                 return error("目录不存在: " + basePathStr, System.currentTimeMillis() - startTime);

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -130,6 +131,8 @@ public class GlobTool extends BaseTool {
             }
             return success(sb.toString().trim(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("查找失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +55,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -91,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -55,7 +54,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -93,8 +92,6 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -92,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -50,7 +49,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -59,8 +58,6 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -48,7 +50,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -57,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -58,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {


### PR DESCRIPTION
  变更类型

  - [x] 新功能 (feature)
  - [x] 重构 (refactor)
  - [x] 问题修复 (bug fix)
  - [x] 文档更新 (documentation)

  变更摘要

    22 files changed, +371 / -72。核心变更为：引入统一权限管道 PermissionGate 与 Sandbox
  沙箱，将工具执行的安全/确认决策从分散的 isReadOnly() 判断收敛到单一入口，并为 Read/Write/Edit/Glob 工具加上 workspace
  边界约束，同时修复 BashTool 超时失效问题。

  ---
  一、统一权限管道 PermissionGate

  问题：原先 AgentLoop 通过各工具自带的 isReadOnly()
  决定是否弹确认，权限决策分散在工具类中，无法集中拦截危险操作（越界读取、危险命令等），也难以对路径越界做统一判定。

  改动：
  - 新增 PermissionGate：作为 AgentLoop 在分发工具前调用的唯一权限决策入口，返回 PermissionResult（DENY / WARN /
  ALLOW）三态
  - 决策规则：read/glob 仅路径越界（workspace 之外）才 WARN，否则 ALLOW；write/edit 固定 WARN；bash 先过 Gate 1
  硬拒绝列表（rm -rf /、sudo、shutdown、mkfs 等）再固定 WARN，并对删除/写系统目录/强制推送等危险模式追加提示；未知工具
  WARN
  - 新增 PermissionResult（record，含 Type 枚举与 deny/warn/ALLOW 静态工厂）与
  WorkspaceSecurityException（路径为空/非法时由 Sandbox 抛出）
  - AgentLoop 移除 requiresConfirmation()，改为 PermissionGate.check()：DENY 直接报错并写回 toolResult、WARN
  弹确认、ALLOW 静默放行

  二、Sandbox 沙箱路径控制

  问题：工具直接操作文件系统，缺少统一的 workspace 边界与会话根目录约束，越界访问无法集中判定。

  改动：
  - 新增 Sandbox：通用路径解析（resolve 展开 ~、相对 workspace 根解析、normalize）与 isWithinWorkspace()
  越界检测；未显式 init 时降级为 user.dir
  - ThoughtCodingContext 启动时以当前工作目录为 workspace 根调用 Sandbox.init()
  - ReadTool / WriteTool / EditTool / GlobTool 统一经 Sandbox.resolve() 解析路径，并捕获 WorkspaceSecurityException
  返回友好错误

  三、BashTool 超时修复

  问题：waitFor(timeout) 期间主线程被 readLine() 阻塞消费 stdout，导致超时无法及时触发，命令可能挂死。

  改动：
  - 将 stdout 消费放到后台 reader 线程，主线程只负责 waitFor(timeout) 与超时 destroyForcibly()，进程退出后再 join reader
  收尾剩余输出

  四、CLI / 交互体验优化

  问题：流式文本与工具确认框、工具结果挤在一起可读性差；LangChainService 残留散落的 System.out.println()。

  改动：
  - 移除 LangChainService 中的 System.out.println()
  - 在 AgentLoop 中工具确认前/后、结果输出后插入空行，分隔流式文本、确认框与工具结果

  五、包结构重构与清理

  问题：工具相关类散落在 com.thoughtcoding.tools 包，与新增的 tool 子模块（PermissionGate/Sandbox）命名不一致。

  改动：
  - 工具基类与工具类由 com.thoughtcoding.tools 重命名/迁移至 com.thoughtcoding.tool（含
  BaseTool/ToolDispatcher/ToolRegistry/ToolSpecificationFactory 及 tool/tools 下五个内置工具），同步更新所有 import 与
  README 示例
  - 清理遗留的沙箱相关 TODO 注释；在直接命令检测处补充 TODO：优化正则检测，降低误判率