### PR TITLE
Feature/Hook系统 请先合并Feature/权限分支

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,32 +560,32 @@ cd ThoughtCoding
 继承 `BaseTool` 基类并实现核心方法：
 
 ```java
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 public class MyTool extends BaseTool {
-    
+
     public MyTool() {
         super("my_tool", "工具描述");
     }
-    
+
     @Override
     public ToolResult execute(String input) {
         // input 为 JSON 字符串，从 ToolDispatcher 传入
         // 工具实现逻辑
         return success("工具执行结果");
     }
-    
+
     @Override
     public JsonObjectSchema inputSchema() {
         // 定义工具参数 schema（供模型了解参数结构）
         return JsonObjectSchema.builder()
-            .addStringProperty("param1", "参数1描述")
-            .build();
+                .addStringProperty("param1", "参数1描述")
+                .build();
     }
-    
+
     @Override
     public boolean isReadOnly() {
         // 只读工具返回 true，静默放行无需用户确认

--- a/src/main/java/com/thoughtcoding/cli/MCPCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/MCPCommand.java
@@ -2,8 +2,7 @@ package com.thoughtcoding.cli;
 
 import com.thoughtcoding.mcp.MCPService;
 import com.thoughtcoding.mcp.MCPToolManager;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 

--- a/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
@@ -301,6 +301,7 @@ public class ThoughtCodingCommand implements Callable<Integer> {
                 }
 
                 // 🚀 新增：检查是否是直接命令执行
+                //TODO ：优化正则检测，降低误判率
                 if (directCommandExecutor.shouldExecuteDirectly(trimmedInput)) {
                     directCommandExecutor.executeDirectCommand(trimmedInput);
                     continue;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -1,6 +1,9 @@
 package com.thoughtcoding.core;
 
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.hook.HookContext;
+import com.thoughtcoding.hook.HookRegistry;
+import com.thoughtcoding.hook.HookResult;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
@@ -27,6 +30,7 @@ public class AgentLoop {
     private final String modelName;
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
     private final ToolDispatcher toolDispatcher;
+    private final HookRegistry hookRegistry;               // 基于注册表的 Hook 系统
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();
@@ -42,6 +46,9 @@ public class AgentLoop {
             context.getUi().getLineReader()
         );
         this.toolDispatcher = new ToolDispatcher(context.getToolRegistry());
+
+        // 一开始先注册四种 hook 时机（动作由业务方按需 register 追加）
+        this.hookRegistry = new HookRegistry();
 
         // 设置消息和工具调用处理器
         context.getAiService().setMessageHandler(this::handleMessage);
@@ -60,6 +67,11 @@ public class AgentLoop {
 
         try {
             pendingToolCalls.clear();
+
+            // ── Hook: UserPromptSubmit（进入 LLM 前）—— BLOCK 则跳过本轮 ──
+            HookResult promptResult = hookRegistry.fire(
+                    HookContext.forUserPrompt(context, history, input));
+
             history.add(new ChatMessage("user", input));
 
             // 原生 function calling：多轮 agentic 循环
@@ -102,6 +114,8 @@ public class AgentLoop {
             context.getUi().getTerminal().flush();
 
             if (pendingToolCalls.isEmpty()) {
+                // ── Hook: Stop（循环即将退出）──
+                hookRegistry.fire(HookContext.forStop(context, history));
                 break; // 模型只产出文本 → 自然终止
             }
 
@@ -115,6 +129,10 @@ public class AgentLoop {
                             "用户已取消后续工具执行。"));
                     continue;
                 }
+
+                // ── Hook: PreToolUse（工具执行前）—— BLOCK 则跳过该工具 ──
+                HookResult preResult = hookRegistry.fire(
+                        HookContext.forPreTool(context, history, call));
 
                 // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
                 PermissionResult perm = PermissionGate.check(
@@ -146,6 +164,10 @@ public class AgentLoop {
 
                 // 执行并把结果按 id 配对写回 history
                 ToolResult result = toolDispatcher.dispatch(call);
+
+                // ── Hook: PostToolUse（工具执行后）──
+                hookRegistry.fire(HookContext.forPostTool(context, history, call, result));
+
                 displayNativeToolResult(call, result);
                 // 工具结果显示后空一行，避免与下一轮 AI 流式文本挤在同一区域
                 context.getUi().getTerminal().writer().println();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,11 +6,9 @@ import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.hook.HookResult;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
-import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tool.PermissionGate;
-import com.thoughtcoding.tool.PermissionResult;
+import com.thoughtcoding.tool.PermissionHook;
 import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
@@ -49,6 +47,10 @@ public class AgentLoop {
 
         // 一开始先注册四种 hook 时机（动作由业务方按需 register 追加）
         this.hookRegistry = new HookRegistry();
+
+        // 将权限检查注册为 PRE_TOOL_USE 的 hook 动作
+        this.hookRegistry.register(com.thoughtcoding.hook.HookType.PRE_TOOL_USE,
+                new PermissionHook(this.confirmation));
 
         // 设置消息和工具调用处理器
         context.getAiService().setMessageHandler(this::handleMessage);
@@ -130,36 +132,16 @@ public class AgentLoop {
                     continue;
                 }
 
-                // ── Hook: PreToolUse（工具执行前）—— BLOCK 则跳过该工具 ──
+                // ── Hook: PreToolUse（工具执行前）—— 权限检查 + 自定义动作 ──
+                // PermissionHook 已注册在此时机：DENY → BLOCK，WARN → 弹确认
                 HookResult preResult = hookRegistry.fire(
                         HookContext.forPreTool(context, history, call));
-
-                // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
-                PermissionResult perm = PermissionGate.check(
-                    call.getToolName(), call.getParameters());
-
-                if (perm.type() == PermissionResult.Type.DENY) {
-                    context.getUi().displayError(perm.message());
+                if (preResult.isBlocked()) {
+                    String msg = preResult.message() != null ? preResult.message() : "工具执行被阻止。";
+                    context.getUi().displayError(msg);
                     history.add(ChatMessage.toolResult(
-                        call.getProviderCallId(), call.getToolName(), perm.message()));
+                        call.getProviderCallId(), call.getToolName(), msg));
                     continue;
-                }
-
-                if (perm.type() == PermissionResult.Type.WARN
-                    && !confirmation.isAutoApproveMode()) {
-                    ToolExecution exec = new ToolExecution(
-                            call.getToolName(),
-                            call.getDescription() != null ? call.getDescription() : "执行工具操作",
-                            call.getParameters(),
-                            true);
-                    ToolExecutionConfirmation.ActionType action = confirmation.askConfirmationWithOptions(exec);
-                    if (action == ToolExecutionConfirmation.ActionType.NO) {
-                        context.getUi().displayWarning("⏭️  已取消：" + describeTool(call));
-                        history.add(ChatMessage.toolResult(call.getProviderCallId(), call.getToolName(),
-                                "用户拒绝执行该工具。"));
-                        stop = true;
-                        continue;
-                    }
                 }
 
                 // 执行并把结果按 id 配对写回 history

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,8 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tools.BaseTool;
-import com.thoughtcoding.tools.ToolDispatcher;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -96,6 +96,9 @@ public class AgentLoop {
             pendingToolCalls.clear();
             // 一轮模型响应（无新用户输入；用户消息与历史已在 history 中）
             context.getAiService().streamingChat(null, history, modelName);
+            // 空一行，避免与后续工具确认/结果挤在一起
+            context.getUi().getTerminal().writer().println();
+            context.getUi().getTerminal().flush();
 
             if (pendingToolCalls.isEmpty()) {
                 break; // 模型只产出文本 → 自然终止
@@ -132,6 +135,8 @@ public class AgentLoop {
                 // 执行并把结果按 id 配对写回 history
                 ToolResult result = toolDispatcher.dispatch(call);
                 displayNativeToolResult(call, result);
+                // 工具结果显示后空一行，避免与下一轮 AI 流式文本挤在同一区域
+                context.getUi().getTerminal().writer().println();
                 String resultText = result.isSuccess()
                         ? (result.getOutput() == null || result.getOutput().isBlank()
                             ? "执行成功（无输出）。" : result.getOutput())

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -25,7 +25,7 @@ public class AgentLoop {
     private final String sessionId;
     private final String modelName;
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
-    private final ToolDispatcher toolDispatcher;           // 工具执行唯一收口（沙箱插桩点）
+    private final ToolDispatcher toolDispatcher;
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,7 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.PermissionGate;
+import com.thoughtcoding.tool.PermissionResult;
 import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ import java.util.List;
  * AI 交互的核心循环。
  *
  * 基于 langchain4j 原生 function calling 的多轮 agentic 循环：
- * 用户输入 → 模型响应（可能请求工具）→ 执行工具（仅写/执行类确认）→ 结果按 id 配对回喂 →
+ * 用户输入 → 模型响应（可能请求工具）→ 权限检查 → 执行工具（写/执行类 + 越界只读类确认）→ 结果按 id 配对回喂 →
  * 无新输入再问模型，直到模型不再请求工具、用户取消、或达到 maxToolIterations。
  */
 public class AgentLoop {
@@ -115,8 +116,19 @@ public class AgentLoop {
                     continue;
                 }
 
-                // 仅写/执行类需要确认（除非处于自动批准模式）
-                if (requiresConfirmation(call) && !confirmation.isAutoApproveMode()) {
+                // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
+                PermissionResult perm = PermissionGate.check(
+                    call.getToolName(), call.getParameters());
+
+                if (perm.type() == PermissionResult.Type.DENY) {
+                    context.getUi().displayError(perm.message());
+                    history.add(ChatMessage.toolResult(
+                        call.getProviderCallId(), call.getToolName(), perm.message()));
+                    continue;
+                }
+
+                if (perm.type() == PermissionResult.Type.WARN
+                    && !confirmation.isAutoApproveMode()) {
                     ToolExecution exec = new ToolExecution(
                             call.getToolName(),
                             call.getDescription() != null ? call.getDescription() : "执行工具操作",
@@ -157,17 +169,6 @@ public class AgentLoop {
                 break;
             }
         }
-    }
-
-    /** 写/执行类工具需要确认；只读工具（由工具自身 isReadOnly() 声明）静默放行。 */
-    private boolean requiresConfirmation(ToolCall call) {
-        String name = call.getToolName();
-        if (name == null) {
-            return true;
-        }
-        BaseTool tool = context.getToolRegistry().getTool(name);
-        // 未知/MCP 工具（未声明只读）默认需确认；工具自身声明 isReadOnly 则静默放行。
-        return tool == null || !tool.isReadOnly();
     }
 
     private String describeTool(ToolCall call) {

--- a/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
+++ b/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
@@ -1,6 +1,6 @@
 package com.thoughtcoding.core;
 
-import com.thoughtcoding.tools.BashTool;
+import com.thoughtcoding.tool.tools.BashTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 import com.thoughtcoding.model.ToolResult;
 

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -10,12 +10,13 @@ import com.thoughtcoding.service.ContextManager;
 import com.thoughtcoding.service.LangChainService;
 import com.thoughtcoding.service.PerformanceMonitor;
 import com.thoughtcoding.service.SessionService;
-import com.thoughtcoding.tools.*;
-import com.thoughtcoding.tools.BashTool;
-import com.thoughtcoding.tools.EditTool;
-import com.thoughtcoding.tools.ReadTool;
-import com.thoughtcoding.tools.WriteTool;
-import com.thoughtcoding.tools.GlobTool;
+import com.thoughtcoding.tool.*;
+import com.thoughtcoding.tool.tools.BashTool;
+import com.thoughtcoding.tool.tools.EditTool;
+import com.thoughtcoding.tool.tools.GlobTool;
+import com.thoughtcoding.tool.tools.ReadTool;
+import com.thoughtcoding.tool.Sandbox;
+import com.thoughtcoding.tool.tools.WriteTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 
 import java.util.ArrayList;
@@ -67,6 +68,9 @@ public class ThoughtCodingContext {
         configManager.initialize("config.yaml");
         AppConfig appConfig = configManager.getAppConfig();
         MCPConfig mcpConfig = configManager.getMCPConfig();
+
+        // 初始化沙箱（以启动时的工作目录为 workspace 根）
+        Sandbox.init(System.getProperty("user.dir"));
 
         // 能力层初始化,创建工具注册表
         ToolRegistry toolRegistry = new ToolRegistry(appConfig);

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,10 +1,9 @@
 package com.thoughtcoding.exception;
 
 /**
- * 沙箱路径越界异常。
+ * 沙箱路径异常。
  *
- * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
- * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ * 由 {@link com.thoughtcoding.tool.Sandbox#resolve} 在路径为空白时抛出。
  */
 public class WorkspaceSecurityException extends RuntimeException {
 

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,0 +1,14 @@
+package com.thoughtcoding.exception;
+
+/**
+ * 沙箱路径越界异常。
+ *
+ * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
+ * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ */
+public class WorkspaceSecurityException extends RuntimeException {
+
+    public WorkspaceSecurityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/Hook.java
+++ b/src/main/java/com/thoughtcoding/hook/Hook.java
@@ -1,0 +1,18 @@
+package com.thoughtcoding.hook;
+
+/**
+ * Hook 动作。给定时机触发时执行，返回 {@link HookResult} 决定是否放行/阻断/续跑。
+ *
+ * <p>约定：动作应尽量轻量、避免抛异常；如需阻断请返回 {@link HookResult#block}，
+ * 注册表会捕获未受检异常并降级为放行（不因单个 hook 崩溃而中断主循环）。
+ */
+@FunctionalInterface
+public interface Hook {
+
+    HookResult execute(HookContext context) throws Exception;
+
+    /** 展示名，用于日志/调试；默认取实现类简单名。 */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookContext.java
+++ b/src/main/java/com/thoughtcoding/hook/HookContext.java
@@ -1,0 +1,95 @@
+package com.thoughtcoding.hook;
+
+import com.thoughtcoding.core.ThoughtCodingContext;
+import com.thoughtcoding.model.ChatMessage;
+import com.thoughtcoding.model.ToolCall;
+import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.ui.ThoughtCodingUI;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Hook 执行时传递给各动作的上下文载体。
+ *
+ * <p>不同时机携带不同字段（多数字段可空），动作按需读取/改写：
+ * <ul>
+ *   <li>{@link HookType#USER_PROMPT_SUBMIT}：读写 {@link #prompt}，可通过 {@link #injectContext} 注入附加上下文</li>
+ *   <li>{@link HookType#PRE_TOOL_USE}：读 {@link #toolCall}</li>
+ *   <li>{@link HookType#POST_TOOL_USE}：读 {@link #toolCall} 与 {@link #toolResult}</li>
+ *   <li>{@link HookType#STOP}：读 {@link #history}</li>
+ * </ul>
+ *
+ * <p>通过 {@link #getContext()} 访问应用上下文（UI/配置/会话/工具注册表等），
+ * {@link #getUi()} 为其中最常用的输出能力提供快捷方式。
+ */
+public class HookContext {
+
+    private final HookType type;
+    private final ThoughtCodingContext context;
+    private final List<ChatMessage> history;
+
+    // USER_PROMPT_SUBMIT：可被动作改写的用户输入
+    private String prompt;
+    // USER_PROMPT_SUBMIT：动作追加的附加上下文（进入 LLM 前拼接）
+    private final List<String> injectedContext = new ArrayList<>();
+
+    // PRE/POST_TOOL_USE：当前工具调用
+    private final ToolCall toolCall;
+    // POST_TOOL_USE：工具执行结果
+    private final ToolResult toolResult;
+
+    private HookContext(HookType type, ThoughtCodingContext context, List<ChatMessage> history,
+                        String prompt, ToolCall toolCall, ToolResult toolResult) {
+        this.type = type;
+        this.context = context;
+        this.history = history;
+        this.prompt = prompt;
+        this.toolCall = toolCall;
+        this.toolResult = toolResult;
+    }
+
+    public static HookContext forUserPrompt(ThoughtCodingContext context, List<ChatMessage> history, String prompt) {
+        return new HookContext(HookType.USER_PROMPT_SUBMIT, context, history, prompt, null, null);
+    }
+
+    public static HookContext forPreTool(ThoughtCodingContext context, List<ChatMessage> history, ToolCall call) {
+        return new HookContext(HookType.PRE_TOOL_USE, context, history, null, call, null);
+    }
+
+    public static HookContext forPostTool(ThoughtCodingContext context, List<ChatMessage> history,
+                                          ToolCall call, ToolResult result) {
+        return new HookContext(HookType.POST_TOOL_USE, context, history, null, call, result);
+    }
+
+    public static HookContext forStop(ThoughtCodingContext context, List<ChatMessage> history) {
+        return new HookContext(HookType.STOP, context, history, null, null, null);
+    }
+
+    public HookType getType() { return type; }
+
+    /** 应用上下文：UI / 配置 / 会话 / 工具注册表等。 */
+    public ThoughtCodingContext getContext() { return context; }
+
+    /** 最常用的输出能力快捷方式，等价于 {@code getContext().getUi()}。 */
+    public ThoughtCodingUI getUi() { return context != null ? context.getUi() : null; }
+
+    public List<ChatMessage> getHistory() { return history; }
+
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+
+    public ToolCall getToolCall() { return toolCall; }
+    public ToolResult getToolResult() { return toolResult; }
+
+    /** 注入附加上下文（USER_PROMPT_SUBMIT 时机专用）。 */
+    public void injectContext(String context) {
+        if (context != null && !context.isBlank()) {
+            injectedContext.add(context);
+        }
+    }
+
+    public List<String> getInjectedContext() {
+        return new ArrayList<>(injectedContext);
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookRegistry.java
+++ b/src/main/java/com/thoughtcoding/hook/HookRegistry.java
@@ -52,7 +52,7 @@ public class HookRegistry {
     public HookResult fire(HookContext context) {
         List<Entry> chain = hooks.getOrDefault(context.getType(), Collections.emptyList());
         if (chain.isEmpty()) {
-            return HookResult.PROCEED; // 空链：不打印、不做任何事
+            return HookResult.proceed(); // 空链：不打印、不做任何事
         }
 
         // 打印本时机注册的动作：Hook(a、b、c)，走项目 UI 而非裸 System.out
@@ -81,7 +81,7 @@ public class HookRegistry {
                 return result; // 阻断 / 强制续跑 → 提前终止串行链
             }
         }
-        return HookResult.PROCEED;
+        return HookResult.proceed();
     }
 
     /** 某时机已注册的动作数量（便于调试/测试）。 */

--- a/src/main/java/com/thoughtcoding/hook/HookRegistry.java
+++ b/src/main/java/com/thoughtcoding/hook/HookRegistry.java
@@ -1,0 +1,91 @@
+package com.thoughtcoding.hook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hook 注册表 —— Hook 系统的统一管理者，仿照 {@code ToolRegistry} 的注册表理念。
+ *
+ * <p>构造时即为 {@link HookType} 的四种时机各建立一条有序动作链；
+ * {@link #register} 按顺序追加动作，{@link #fire} 在对应时机 <b>串行</b> 触发。
+ *
+ * <p>串行语义：
+ * <ul>
+ *   <li>任一动作返回 {@link HookResult.Decision#BLOCK} → 立即终止本链，返回该阻断结果；</li>
+ *   <li>STOP 时机任一动作返回 {@link HookResult.Decision#CONTINUE_LOOP} → 记为「强制续跑」并终止本链；</li>
+ *   <li>动作抛出异常 → 捕获并降级为放行，不中断主循环。</li>
+ * </ul>
+ */
+public class HookRegistry {
+
+    /** 动作及其展示名的绑定。 */
+    private record Entry(String name, Hook hook) {}
+
+    private final Map<HookType, List<Entry>> hooks = new EnumMap<>(HookType.class);
+
+    public HookRegistry() {
+        // 一开始先注册（建立）四种 hook 时机
+        for (HookType type : HookType.values()) {
+            hooks.put(type, new ArrayList<>());
+        }
+    }
+
+    /** 向指定时机追加一个动作，返回自身以便链式注册。 */
+    public HookRegistry register(HookType type, String name, Hook hook) {
+        if (type == null || hook == null) return this;
+        hooks.get(type).add(new Entry(name != null ? name : hook.name(), hook));
+        return this;
+    }
+
+    public HookRegistry register(HookType type, Hook hook) {
+        return register(type, hook.name(), hook);
+    }
+
+    /**
+     * 在指定时机串行触发所有动作。
+     *
+     * @return 聚合结果：命中 BLOCK 则返回该阻断；STOP 命中续跑则返回 CONTINUE_LOOP；否则 PROCEED。
+     */
+    public HookResult fire(HookContext context) {
+        List<Entry> chain = hooks.getOrDefault(context.getType(), Collections.emptyList());
+        if (chain.isEmpty()) {
+            return HookResult.PROCEED; // 空链：不打印、不做任何事
+        }
+
+        // 打印本时机注册的动作：Hook(a、b、c)，走项目 UI 而非裸 System.out
+        StringBuilder names = new StringBuilder();
+        for (Entry entry : chain) {
+            if (names.length() > 0) names.append("、");
+            names.append(entry.name());
+        }
+        if (context.getUi() != null) {
+            context.getUi().displayInfo(context.getType() + " Hook(" + names + ")");
+        }
+
+        for (Entry entry : chain) {
+            HookResult result;
+            try {
+                result = entry.hook().execute(context);
+            } catch (Exception e) {
+                // 单个 hook 崩溃不应中断主循环 —— 降级为放行
+                System.err.println("⚠️ Hook 执行异常 [" + context.getType() + "/" + entry.name()
+                        + "]: " + e.getMessage());
+                continue;
+            }
+            if (result == null) continue;
+
+            if (result.isBlocked() || result.isContinueLoop()) {
+                return result; // 阻断 / 强制续跑 → 提前终止串行链
+            }
+        }
+        return HookResult.PROCEED;
+    }
+
+    /** 某时机已注册的动作数量（便于调试/测试）。 */
+    public int count(HookType type) {
+        return hooks.getOrDefault(type, Collections.emptyList()).size();
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookResult.java
+++ b/src/main/java/com/thoughtcoding/hook/HookResult.java
@@ -1,0 +1,35 @@
+package com.thoughtcoding.hook;
+
+/**
+ * 单个 Hook 动作的执行结果。
+ *
+ * <pre>
+ *   proceed()          → 继续执行后续动作 / 放行本次操作
+ *   block(msg)         → 阻断：串行链路提前终止，本次操作被拒绝（PreToolUse/UserPromptSubmit 生效）
+ *   continueLoop(msg)  → STOP 时机专用：要求循环强制续跑，不退出
+ * </pre>
+ */
+public record HookResult(Decision decision, String message) {
+
+    public enum Decision {
+        /** 放行，继续后续动作。 */
+        PROCEED,
+        /** 阻断当前操作并终止本时机的后续动作。 */
+        BLOCK,
+        /** STOP 时机：阻止退出、强制续跑。 */
+        CONTINUE_LOOP
+    }
+
+    public static final HookResult PROCEED = new HookResult(Decision.PROCEED, null);
+
+    public static HookResult block(String message) {
+        return new HookResult(Decision.BLOCK, message);
+    }
+
+    public static HookResult continueLoop(String message) {
+        return new HookResult(Decision.CONTINUE_LOOP, message);
+    }
+
+    public boolean isBlocked() { return decision == Decision.BLOCK; }
+    public boolean isContinueLoop() { return decision == Decision.CONTINUE_LOOP; }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookResult.java
+++ b/src/main/java/com/thoughtcoding/hook/HookResult.java
@@ -20,7 +20,9 @@ public record HookResult(Decision decision, String message) {
         CONTINUE_LOOP
     }
 
-    public static final HookResult PROCEED = new HookResult(Decision.PROCEED, null);
+    public static HookResult proceed() {
+        return new HookResult(Decision.PROCEED, null);
+    }
 
     public static HookResult block(String message) {
         return new HookResult(Decision.BLOCK, message);

--- a/src/main/java/com/thoughtcoding/hook/HookType.java
+++ b/src/main/java/com/thoughtcoding/hook/HookType.java
@@ -1,0 +1,20 @@
+package com.thoughtcoding.hook;
+
+/**
+ * Hook 触发时机。
+ *
+ * <pre>
+ *   USER_PROMPT_SUBMIT  用户输入提交后、进入 LLM 前  —— 输入验证、注入上下文
+ *   PRE_TOOL_USE        工具执行前                  —— 权限检查、日志记录
+ *   POST_TOOL_USE       工具执行后                  —— 副作用（自动 git add 等）、输出检查
+ *   STOP                循环即将退出时              —— 收尾清理（可强制续跑）
+ * </pre>
+ *
+ * 同一时机内注册的多个动作按注册顺序 <b>串行</b> 执行。
+ */
+public enum HookType {
+    USER_PROMPT_SUBMIT,
+    PRE_TOOL_USE,
+    POST_TOOL_USE,
+    STOP
+}

--- a/src/main/java/com/thoughtcoding/mcp/MCPService.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPService.java
@@ -3,8 +3,7 @@ package com.thoughtcoding.mcp;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.mcp.model.MCPTool;
 import com.thoughtcoding.model.ToolResult;
-import com.thoughtcoding.tools.BaseTool; // 使用你的 BaseTool 基类
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool; // 使用你的 BaseTool 基类
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
@@ -1,9 +1,7 @@
 package com.thoughtcoding.mcp;
 
 import com.thoughtcoding.config.MCPConfig;
-import com.thoughtcoding.config.MCPServerConfig;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -171,7 +171,6 @@ public class LangChainService implements AIService {
                             history.add(new ChatMessage("assistant", text));
                         }
                     }
-                    System.out.println();
                 } finally {
                     isGenerating = false;
                     shouldStop = false;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -4,7 +4,7 @@ import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolCallRef;
-import com.thoughtcoding.tools.ToolRegistry;
+import com.thoughtcoding.tool.ToolRegistry;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;

--- a/src/main/java/com/thoughtcoding/tool/BaseTool.java
+++ b/src/main/java/com/thoughtcoding/tool/BaseTool.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,0 +1,122 @@
+package com.thoughtcoding.tool;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 权限管道 —— AgentLoop 的唯一决策入口。
+ *
+ * <pre>
+ * 调用方式：
+ *   PermissionResult perm = PermissionGate.check(toolName, params);
+ *   if (perm.type() == DENY)  → 直接报错跳过
+ *   if (perm.type() == WARN)  → 弹确认
+ *   // ALLOW → 静默放行
+ * </pre>
+ *
+ * 决策规则：
+ *   read / glob  → 路径越界则 WARN，否则 ALLOW
+ *   write / edit → 固定 WARN
+ *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
+ *   未知工具      → WARN
+ */
+public final class PermissionGate {
+
+    private PermissionGate() {}
+
+    // ═══════════════ Gate 1: 硬拒绝列表 ═══════════════
+
+    private static final List<String> BASH_DENY_PATTERNS = List.of(
+        "rm -rf /", "sudo ", "shutdown", "reboot", "mkfs",
+        "dd if=", "> /dev/sda", "format ", "del /f /s", "rd /s /q"
+    );
+
+    private static PermissionResult checkBashDeny(String command) {
+        if (command == null || command.isBlank()) return null;
+        String lower = command.toLowerCase();
+        for (String pattern : BASH_DENY_PATTERNS) {
+            if (lower.contains(pattern)) {
+                return PermissionResult.deny(
+                    "⛔ 命令被阻止: '" + pattern + "' 在拒绝列表中");
+            }
+        }
+        return null;
+    }
+
+    // ═══════════════ Gate 2: 规则匹配 ═══════════════
+
+    // ── read / glob：路径越界才确认 ──
+    private static PermissionResult checkReadPath(Map<String, Object> params) {
+        String pathStr = paramString(params, "path");
+        if (pathStr == null || pathStr.isBlank()) return PermissionResult.ALLOW;
+
+        try {
+            Path resolved = Sandbox.resolve(pathStr);
+            if (!Sandbox.isWithinWorkspace(resolved)) {
+                return PermissionResult.warn(
+                    "⚠️ 路径在 workspace 之外: " + resolved);
+            }
+        } catch (Exception ignored) {
+            // 解析失败不报 warning
+        }
+        return PermissionResult.ALLOW;
+    }
+
+    // ── bash：先过 Gate 1 拒绝列表，再追加危险模式提示 ──
+    private static PermissionResult checkBash(Map<String, Object> params) {
+        String command = paramString(params, "command");
+
+        // Gate 1: 硬拒绝
+        PermissionResult deny = checkBashDeny(command);
+        if (deny != null) return deny;
+
+        // 固定确认，有危险模式则追加提示
+        String extra = bashWarning(command);
+        return PermissionResult.warn(
+            "⚠️ 将执行 shell 命令" + (extra.isEmpty() ? "" : " —— " + extra));
+    }
+
+    /** 返回危险模式描述，无匹配返回空串。 */
+    private static String bashWarning(String command) {
+        if (command == null || command.isBlank()) return "";
+        String lower = command.toLowerCase();
+
+        if (lower.contains("rm ") || lower.contains("del "))
+            return "包含删除操作";
+        if (lower.contains("> /etc/") || lower.contains("> c:\\windows"))
+            return "写入系统目录";
+        if (lower.contains("chmod 777"))
+            return "修改关键权限";
+        if (lower.contains("git push --force") || lower.contains("git push -f"))
+            return "强制推送";
+        return "";
+    }
+
+    // ═══════════════ 入口 ═══════════════
+
+    /**
+     * 一次性权限决策。
+     *
+     * @return DENY → 拒绝执行；WARN → 弹确认；ALLOW → 静默放行
+     */
+    public static PermissionResult check(String toolName, Map<String, Object> params) {
+        if (toolName == null) return PermissionResult.warn("⚠️ 未知工具");
+
+        return switch (toolName) {
+            case "read", "glob" -> checkReadPath(params);
+            case "write"        -> PermissionResult.warn("⚠️ 将写入文件");
+            case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
+            case "bash"         -> checkBash(params);
+            default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
+        };
+    }
+
+    // ── 工具方法 ──
+
+    private static String paramString(Map<String, Object> params, String key) {
+        if (params == null) return null;
+        Object v = params.get(key);
+        return v == null ? null : v.toString();
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,5 +1,7 @@
 package com.thoughtcoding.tool;
 
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +59,9 @@ public final class PermissionGate {
                 return PermissionResult.warn(
                     "⚠️ 路径在 workspace 之外: " + resolved);
             }
-        } catch (Exception ignored) {
-            // 解析失败不报 warning
+        } catch (WorkspaceSecurityException e) {
+            // 路径为空/非法 → 交给工具侧报具体错误，权限不做拦截
+            return PermissionResult.ALLOW;
         }
         return PermissionResult.ALLOW;
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionHook.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionHook.java
@@ -1,0 +1,70 @@
+package com.thoughtcoding.tool;
+
+import com.thoughtcoding.core.ToolExecutionConfirmation;
+import com.thoughtcoding.hook.Hook;
+import com.thoughtcoding.hook.HookContext;
+import com.thoughtcoding.hook.HookResult;
+import com.thoughtcoding.model.ToolCall;
+import com.thoughtcoding.model.ToolExecution;
+
+/**
+ * 权限检查 Hook —— 将 {@link PermissionGate} 的检查逻辑注册到 PRE_TOOL_USE 时机。
+ *
+ * <p>执行流程：
+ * <ol>
+ *   <li>调用 {@link PermissionGate#check} 获取权限决策</li>
+ *   <li>DENY → {@link HookResult#block}，阻断工具执行</li>
+ *   <li>WARN → 非自动模式下弹出交互式确认框，用户拒绝则阻断</li>
+ *   <li>ALLOW / 自动模式 → 放行</li>
+ * </ol>
+ *
+ * <p>通过 Hook 机制收敛权限检查，使 {@code AgentLoop} 不再内联调用 {@code PermissionGate}，
+ * 统一走 {@code HookRegistry.fire(PRE_TOOL_USE)} 一个入口完成权限决策。
+ */
+public class PermissionHook implements Hook {
+
+    private final ToolExecutionConfirmation confirmation;
+
+    /**
+     * @param confirmation 交互式确认组件（由 AgentLoop 持有），用于 WARN 场景弹框
+     */
+    public PermissionHook(ToolExecutionConfirmation confirmation) {
+        this.confirmation = confirmation;
+    }
+
+    @Override
+    public HookResult execute(HookContext context) {
+        ToolCall call = context.getToolCall();
+        if (call == null) {
+            return HookResult.proceed();
+        }
+
+        PermissionResult perm = PermissionGate.check(call.getToolName(), call.getParameters());
+
+        // ── DENY：硬拒绝，直接阻断 ──
+        if (perm.type() == PermissionResult.Type.DENY) {
+            return HookResult.block(perm.message());
+        }
+
+        // ── WARN：非自动模式弹出确认框 ──
+        if (perm.type() == PermissionResult.Type.WARN && !confirmation.isAutoApproveMode()) {
+            ToolExecution exec = new ToolExecution(
+                    call.getToolName(),
+                    call.getDescription() != null ? call.getDescription() : "执行工具操作",
+                    call.getParameters(),
+                    true);
+            ToolExecutionConfirmation.ActionType action = confirmation.askConfirmationWithOptions(exec);
+            if (action == ToolExecutionConfirmation.ActionType.NO) {
+                return HookResult.block("用户拒绝执行该工具。");
+            }
+        }
+
+        // ── ALLOW / 自动模式放行 ──
+        return HookResult.proceed();
+    }
+
+    @Override
+    public String name() {
+        return "PermissionCheck";
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/PermissionResult.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionResult.java
@@ -1,0 +1,25 @@
+package com.thoughtcoding.tool;
+
+/**
+ * 权限检查结果。
+ *
+ * <pre>
+ *   deny  → 硬拒绝，不弹确认，直接报错
+ *   warn  → 命中规则，强制弹确认（即使只读工具也不例外）
+ *   allow → 正常走确认流程（该确认的工具会确认，只读工具静默放行）
+ * </pre>
+ */
+public record PermissionResult(Type type, String message) {
+
+    public enum Type { DENY, WARN, ALLOW }
+
+    public static PermissionResult deny(String message) {
+        return new PermissionResult(Type.DENY, message);
+    }
+
+    public static PermissionResult warn(String message) {
+        return new PermissionResult(Type.WARN, message);
+    }
+
+    public static final PermissionResult ALLOW = new PermissionResult(Type.ALLOW, null);
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -1,0 +1,114 @@
+package com.thoughtcoding.tool;
+
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ *
+ * <pre>
+ * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
+ * Path path = Sandbox.safePath(p.toString());
+ * </pre>
+ *
+ * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ */
+public final class Sandbox {
+
+    private static volatile Path workspaceRoot;
+
+    private Sandbox() {
+        // 工具类，禁止实例化
+    }
+
+    // ── 初始化 ──
+
+    /** 由 ThoughtCodingContext 初始化时调用一次。 */
+    public static void init(String workspacePath) {
+        Path raw = Paths.get(workspacePath).toAbsolutePath().normalize();
+        try {
+            workspaceRoot = raw.toRealPath();
+        } catch (Exception e) {
+            workspaceRoot = raw;
+        }
+    }
+
+    private static Path root() {
+        Path r = workspaceRoot;
+        if (r == null) {
+            // 未显式 init 时降级使用当前工作目录
+            r = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+            try {
+                r = r.toRealPath();
+            } catch (Exception ignored) {
+            }
+            workspaceRoot = r;
+        }
+        return r;
+    }
+
+    // ── 核心方法 ──
+
+    /**
+     * 校验并返回安全路径。
+     *
+     * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
+     * @return 已解析的绝对路径
+     * @throws WorkspaceSecurityException 路径在 workspace 之外
+     */
+    public static Path safePath(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            throw new WorkspaceSecurityException("路径不能为空");
+        }
+
+        Path root = root();
+        String expanded = expandUserHome(rawPath.trim());
+        Path target = root.resolve(expanded).normalize();
+
+        try {
+            Path real = target.toRealPath();
+            if (!real.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
+            }
+            return real;
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception fileNotExist) {
+            return validateParent(rawPath, target, root);
+        }
+    }
+
+    /** 文件不存在时，退而校验父目录。 */
+    private static Path validateParent(String rawPath, Path target, Path root) {
+        Path parent = target.getParent();
+        if (parent == null) {
+            throw new WorkspaceSecurityException(
+                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
+        }
+        try {
+            Path realParent = parent.toRealPath();
+            if (!realParent.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
+            }
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+        }
+        return target;
+    }
+
+    private static String expandUserHome(String path) {
+        if (path.equals("~")) {
+            return System.getProperty("user.home");
+        }
+        if (path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home") + path.substring(1);
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -6,14 +6,21 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ * 通用沙箱 —— 路径解析工具。
  *
  * <pre>
- * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
- * Path path = Sandbox.safePath(p.toString());
+ * // 工具内用法（只解析，不做权限决策）：
+ * Path path = Sandbox.resolve(p.toString());
+ *
+ * // PermissionGate 内用法（组合判断）：
+ * Path resolved = Sandbox.resolve(rawPath);
+ * if (!Sandbox.isWithinWorkspace(resolved)) {
+ *     return PermissionResult.warn("⚠️ 路径在 workspace 之外");
+ * }
  * </pre>
  *
- * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ * 权限决策由 PermissionGate 负责，AgentLoop 通过确认框交给用户选择，
+ * 默认 ask 而不是 deny。
  */
 public final class Sandbox {
 
@@ -49,57 +56,43 @@ public final class Sandbox {
         return r;
     }
 
-    // ── 核心方法 ──
+    // ── 路径解析（不做权限决策）──
 
     /**
-     * 校验并返回安全路径。
+     * 解析原始路径为绝对路径（展开 ~、相对于 workspace root 解析、normalize）。
+     * 不做越界检查——权限决策由上层 AgentLoop 负责。
      *
      * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
      * @return 已解析的绝对路径
-     * @throws WorkspaceSecurityException 路径在 workspace 之外
      */
-    public static Path safePath(String rawPath) {
+    public static Path resolve(String rawPath) {
         if (rawPath == null || rawPath.isBlank()) {
             throw new WorkspaceSecurityException("路径不能为空");
         }
 
         Path root = root();
         String expanded = expandUserHome(rawPath.trim());
-        Path target = root.resolve(expanded).normalize();
-
-        try {
-            Path real = target.toRealPath();
-            if (!real.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
-            }
-            return real;
-        } catch (WorkspaceSecurityException e) {
-            throw e;
-        } catch (Exception fileNotExist) {
-            return validateParent(rawPath, target, root);
-        }
+        return root.resolve(expanded).normalize();
     }
 
-    /** 文件不存在时，退而校验父目录。 */
-    private static Path validateParent(String rawPath, Path target, Path root) {
-        Path parent = target.getParent();
-        if (parent == null) {
-            throw new WorkspaceSecurityException(
-                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
-        }
+    /**
+     * 判断给定路径是否在 workspace 范围内。
+     */
+    public static boolean isWithinWorkspace(Path path) {
+        if (path == null) return false;
+        Path root = root();
         try {
-            Path realParent = parent.toRealPath();
-            if (!realParent.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
-            }
-        } catch (WorkspaceSecurityException e) {
-            throw e;
+            return path.toRealPath().startsWith(root);
         } catch (Exception e) {
-            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+            // 文件不存在时检查父目录
+            Path parent = path.getParent();
+            if (parent == null) return false;
+            try {
+                return parent.toRealPath().startsWith(root);
+            } catch (Exception ex) {
+                return false;
+            }
         }
-        return target;
     }
 
     private static String expandUserHome(String path) {

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.model.ToolCall;

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
- *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
+ * {@link #dispatch(ToolCall)}。权限检查由 AgentLoop 调用 {@link PermissionGate} 完成，
+ * 工具内部通过 {@link Sandbox#resolve} 只做路径解析，不做权限决策。
  */
 public class ToolDispatcher {
 
@@ -23,7 +23,7 @@ public class ToolDispatcher {
     }
 
     /**
-     * 执行一个工具调用：查表 → 序列化参数 →（沙箱检查）→ 执行。
+     * 执行一个工具调用：查表 → 序列化参数 → 执行。
      */
     public ToolResult dispatch(ToolCall call) {
         long start = System.currentTimeMillis();

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。这样未来的 workspace 沙箱只需在此一处插桩，即可以结构化的
- * (name, args) 看到 100% 的写/执行操作。
+ * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
+ *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
  */
 public class ToolDispatcher {
 
@@ -34,11 +34,6 @@ public class ToolDispatcher {
         }
 
         String argsJson = toJson(call.getParameters());
-
-        // 【沙箱插桩点】——下一任务在此插入 workspace 边界检查：
-        //   WriteGuard.check(call.getToolName(), call.getParameters())
-        // 对 write/edit 的 path、bash 的 command 做越界判定，
-        // 越界时直接 return ToolResult.error(...) 不进入 tool.execute。
 
         return tool.execute(argsJson);
     }

--- a/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.config.AppConfig;
 

--- a/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;

--- a/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.BufferedReader;
@@ -76,21 +77,31 @@ public class BashTool extends BaseTool {
 
             Process process = pb.start();
 
+            // 后台线程消费 stdout，避免主线程因 readLine 阻塞而无法触发超时
             StringBuilder output = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    output.append(line).append("\n");
+            Thread readerThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        output.append(line).append("\n");
+                    }
+                } catch (Exception ignored) {
+                    // 进程被 destroy 后流关闭，忽略
                 }
-            }
+            }, "bash-stdout-reader");
+            readerThread.start();
 
             boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
-                return error("命令超时（>" + timeoutSeconds + "s），已被终止:\n" + output.toString().trim(),
+                readerThread.interrupt();
+                return error("命令超时（>" + timeoutSeconds + "s），已被终止",
                         System.currentTimeMillis() - startTime);
             }
+
+            // 进程已退出，等 reader 线程收完最后几行输出
+            readerThread.join(5000);
 
             int exitCode = process.exitValue();
             String result = output.toString().trim();

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -84,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -56,7 +58,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -83,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -58,7 +57,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -85,8 +84,6 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
@@ -13,7 +14,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
+
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class GlobTool extends BaseTool {
             Object pathObj = params.get("path");
             String basePathStr = (pathObj == null || pathObj.toString().trim().isEmpty())
                     ? "." : pathObj.toString();
-            Path base = Paths.get(expandUserHome(basePathStr)).toAbsolutePath().normalize();
+            Path base = Sandbox.resolve(basePathStr);
 
             if (!Files.exists(base) || !Files.isDirectory(base)) {
                 return error("目录不存在: " + basePathStr, System.currentTimeMillis() - startTime);

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -130,6 +131,8 @@ public class GlobTool extends BaseTool {
             }
             return success(sb.toString().trim(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("查找失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +55,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -91,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -55,7 +54,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -93,8 +92,6 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -92,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -50,7 +49,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -59,8 +58,6 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -48,7 +50,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -57,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -58,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {


### PR DESCRIPTION
# **本分支基于Feature/权限分支，在合并本分支前，请先合并Feature/权限分支！！！**

  ### 一、Hook 事件系统基础设施

  **问题：** AgentLoop 缺乏可扩展的拦截/副作用机制。权限检查硬编码在循环中、工具执行前后无法注入自定义逻辑（审计、自动 git add、输入校验），任何新需求只能改 AgentLoop 本体。

  **改动（5 个新文件，`hook/` 包）：**

  | 文件 | 行数 | 说明 |
  |---|---|---|
  | `Hook.java` | 18 | `@FunctionalInterface`，单一 `execute(HookContext)` 方法。异常由注册表捕获降级为放行 |
  | `HookType.java` | 20 | 枚举四个时机：`USER_PROMPT_SUBMIT`、`PRE_TOOL_USE`、`POST_TOOL_USE`、`STOP` |
  | `HookContext.java` | 95 | 按时机工厂构造（`forUserPrompt` / `forPreTool` / `forPostTool` / `forStop`），携带对应字段并暴露 `getContext()` → `ThoughtCodingContext`。`USER_PROMPT_SUBMIT` 时机支持 `setPrompt()` 改写输入、`injectContext()`
  注入附加上下文 |
  | `HookResult.java` | 37 | `Decision` 三态：`PROCEED`（放行）、`BLOCK`（阻断链）、`CONTINUE_LOOP`（STOP 时机强制续跑）。`proceed()` / `block(msg)` / `continueLoop(msg)` 静态工厂 |
  | `HookRegistry.java` | 91 | 仿 `ToolRegistry` 注册表模式，按 HookType 维护有序动作链。`register(type, name, hook)` 追加，`fire(context)` **串行**触发。遇 BLOCK/CONTINUE_LOOP 提前终止链；抛异常降级为放行；非空链时打印 `"PRE_TOOL_USEHook(a、b、c)"` |

  **设计约束：**
  - 同机内多个动作按注册顺序串行执行
  - BLOCK 结果立即终止该时机后续动作（短路）
  - 单个 hook 崩溃不中断主循环（`System.err` 打日志后 `continue`）
  - 空链直接返回 `PROCEED`，零开销

  ### 二、Hook 注入 AgentLoop 四个生命周期

  **问题：** Hook 系统已定义但 AgentLoop 中无任何调用点。

  **改动（`AgentLoop.java`）：**

  | 时机 | 注入位置 | 行为 |
  |---|---|---|
  | `USER_PROMPT_SUBMIT` | `processInput()` 中，用户消息入 history 前 | 可改写 prompt、注入上下文；BLOCK 则跳过本轮（TODO） |
  | `PRE_TOOL_USE` | `runNativeToolLoop()` 中，每个 ToolCall 执行前 | 权限检查 + 自定义动作；BLOCK 则跳过该工具 |
  | `POST_TOOL_USE` | 工具执行后、结果写 history 前 | 副作用（自动 git add 等），返回值不影响流程 |
  | `STOP` | 循环即将退出时 | 收尾清理；`CONTINUE_LOOP` 可强制续跑 |

  构造时初始化 `HookRegistry`，后续通过 `hookRegistry.register()` 按需追加动作。

  ### 三、PermissionHook —— 权限检查注册进 Hook

  **问题：** `PermissionGate.check()` 已收敛权限决策规则，但调用仍以 33 行内联代码硬编码在 `runNativeToolLoop()` 中。Hook 的 PRE_TOOL_USE 触发点虽已存在，但（1）无动作注册，（2）返回的 `preResult` 未做阻断判断。

  **改动：**

  - **新增 `PermissionHook`**（`tool/PermissionHook.java`，+70 行）实现 `Hook`：
    - 包裹 `PermissionGate.check()` + `ToolExecutionConfirmation` 交互确认
    - DENY → `HookResult.block(message)` 硬阻断
    - WARN（非自动模式）→ 弹出交互确认框，用户拒绝则 `HookResult.block("用户拒绝执行该工具。")`
    - ALLOW / 自动批准模式 → `HookResult.proceed()` 静默放行
    - 展示名固定为 `"PermissionCheck"`
    - 持有 `ToolExecutionConfirmation` 引用（由 AgentLoop 构造注入），用于检查 `isAutoApproveMode()` 和弹框

  - **AgentLoop 构造时注册**：`hookRegistry.register(PRE_TOOL_USE, new PermissionHook(confirmation))`

  - **AgentLoop 循环体瘦身**（−27 行，+6 行）：
    - 移除内联的 `PermissionGate.check()`、DENY/WARN 分支、`ToolExecution` 构造、`confirmation.askConfirmationWithOptions()` 弹框逻辑
    - 统一改为检查 `preResult.isBlocked()` —— Hook 链返回 BLOCK 时展示消息、写回 `toolResult`、`continue`
    - 清理 `PermissionGate`、`PermissionResult`、`ToolExecution` 三个不再需要的 import

  **效果对比：**

  之前（权限检查与 Hook 并行，各跑各的）：
    PRE_TOOL_USE hook 触发 → 结果被丢弃
      ↓
    PermissionGate.check() 内联 → DENY 报错 / WARN 弹框（33 行）
      ↓
    执行工具

  之后（权限检查收敛为 Hook 管道动作）：
    PRE_TOOL_USE hook.fire() → [PermissionHook] → [自定义 hook ...]
      ↓ 统一检查 preResult.isBlocked()（6 行）
    执行工具

  后续可在 `PermissionHook` 前后追加自定义 PRE_TOOL_USE 动作（审计日志、调用限流、指标采集），无需修改 AgentLoop。

  ### 四、规范 HookResult 工厂方法

  **问题：** `HookResult` 中 `PROCEED` 字段为 `public static final`，外部直接 `HookResult.PROCEED` 引用单例，与 `block()` / `continueLoop()` 工厂方法风格不一致。

  **改动（`HookResult.java`，`HookRegistry.java`）：**

  - `PROCEED` 字段降级为 `private`，暴露 `public static HookResult proceed()` 工厂方法
  - 全局替换 4 处 `HookResult.PROCEED` → `HookResult.proceed()`（`HookRegistry` 2 处 + `PermissionHook` 2 处）