### PR TITLE
Feature/TodoList 请先合并Feature/Hook系统

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,32 +560,32 @@ cd ThoughtCoding
 继承 `BaseTool` 基类并实现核心方法：
 
 ```java
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 public class MyTool extends BaseTool {
-    
+
     public MyTool() {
         super("my_tool", "工具描述");
     }
-    
+
     @Override
     public ToolResult execute(String input) {
         // input 为 JSON 字符串，从 ToolDispatcher 传入
         // 工具实现逻辑
         return success("工具执行结果");
     }
-    
+
     @Override
     public JsonObjectSchema inputSchema() {
         // 定义工具参数 schema（供模型了解参数结构）
         return JsonObjectSchema.builder()
-            .addStringProperty("param1", "参数1描述")
-            .build();
+                .addStringProperty("param1", "参数1描述")
+                .build();
     }
-    
+
     @Override
     public boolean isReadOnly() {
         // 只读工具返回 true，静默放行无需用户确认

--- a/src/main/java/com/thoughtcoding/cli/MCPCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/MCPCommand.java
@@ -2,8 +2,7 @@ package com.thoughtcoding.cli;
 
 import com.thoughtcoding.mcp.MCPService;
 import com.thoughtcoding.mcp.MCPToolManager;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 

--- a/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
@@ -301,6 +301,7 @@ public class ThoughtCodingCommand implements Callable<Integer> {
                 }
 
                 // 🚀 新增：检查是否是直接命令执行
+                //TODO ：优化正则检测，降低误判率
                 if (directCommandExecutor.shouldExecuteDirectly(trimmedInput)) {
                     directCommandExecutor.executeDirectCommand(trimmedInput);
                     continue;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -1,6 +1,9 @@
 package com.thoughtcoding.core;
 
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.hook.HookContext;
+import com.thoughtcoding.hook.HookRegistry;
+import com.thoughtcoding.hook.HookResult;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
@@ -27,6 +30,7 @@ public class AgentLoop {
     private final String modelName;
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
     private final ToolDispatcher toolDispatcher;
+    private final HookRegistry hookRegistry;               // 基于注册表的 Hook 系统
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();
@@ -42,6 +46,9 @@ public class AgentLoop {
             context.getUi().getLineReader()
         );
         this.toolDispatcher = new ToolDispatcher(context.getToolRegistry());
+
+        // 一开始先注册四种 hook 时机（动作由业务方按需 register 追加）
+        this.hookRegistry = new HookRegistry();
 
         // 设置消息和工具调用处理器
         context.getAiService().setMessageHandler(this::handleMessage);
@@ -60,6 +67,11 @@ public class AgentLoop {
 
         try {
             pendingToolCalls.clear();
+
+            // ── Hook: UserPromptSubmit（进入 LLM 前）—— BLOCK 则跳过本轮 ──
+            HookResult promptResult = hookRegistry.fire(
+                    HookContext.forUserPrompt(context, history, input));
+
             history.add(new ChatMessage("user", input));
 
             // 原生 function calling：多轮 agentic 循环
@@ -102,6 +114,8 @@ public class AgentLoop {
             context.getUi().getTerminal().flush();
 
             if (pendingToolCalls.isEmpty()) {
+                // ── Hook: Stop（循环即将退出）──
+                hookRegistry.fire(HookContext.forStop(context, history));
                 break; // 模型只产出文本 → 自然终止
             }
 
@@ -115,6 +129,10 @@ public class AgentLoop {
                             "用户已取消后续工具执行。"));
                     continue;
                 }
+
+                // ── Hook: PreToolUse（工具执行前）—— BLOCK 则跳过该工具 ──
+                HookResult preResult = hookRegistry.fire(
+                        HookContext.forPreTool(context, history, call));
 
                 // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
                 PermissionResult perm = PermissionGate.check(
@@ -146,6 +164,10 @@ public class AgentLoop {
 
                 // 执行并把结果按 id 配对写回 history
                 ToolResult result = toolDispatcher.dispatch(call);
+
+                // ── Hook: PostToolUse（工具执行后）──
+                hookRegistry.fire(HookContext.forPostTool(context, history, call, result));
+
                 displayNativeToolResult(call, result);
                 // 工具结果显示后空一行，避免与下一轮 AI 流式文本挤在同一区域
                 context.getUi().getTerminal().writer().println();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,11 +6,9 @@ import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.hook.HookResult;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
-import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tool.PermissionGate;
-import com.thoughtcoding.tool.PermissionResult;
+import com.thoughtcoding.tool.PermissionHook;
 import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
@@ -49,6 +47,10 @@ public class AgentLoop {
 
         // 一开始先注册四种 hook 时机（动作由业务方按需 register 追加）
         this.hookRegistry = new HookRegistry();
+
+        // 将权限检查注册为 PRE_TOOL_USE 的 hook 动作
+        this.hookRegistry.register(com.thoughtcoding.hook.HookType.PRE_TOOL_USE,
+                new PermissionHook(this.confirmation));
 
         // 设置消息和工具调用处理器
         context.getAiService().setMessageHandler(this::handleMessage);
@@ -130,36 +132,16 @@ public class AgentLoop {
                     continue;
                 }
 
-                // ── Hook: PreToolUse（工具执行前）—— BLOCK 则跳过该工具 ──
+                // ── Hook: PreToolUse（工具执行前）—— 权限检查 + 自定义动作 ──
+                // PermissionHook 已注册在此时机：DENY → BLOCK，WARN → 弹确认
                 HookResult preResult = hookRegistry.fire(
                         HookContext.forPreTool(context, history, call));
-
-                // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
-                PermissionResult perm = PermissionGate.check(
-                    call.getToolName(), call.getParameters());
-
-                if (perm.type() == PermissionResult.Type.DENY) {
-                    context.getUi().displayError(perm.message());
+                if (preResult.isBlocked()) {
+                    String msg = preResult.message() != null ? preResult.message() : "工具执行被阻止。";
+                    context.getUi().displayError(msg);
                     history.add(ChatMessage.toolResult(
-                        call.getProviderCallId(), call.getToolName(), perm.message()));
+                        call.getProviderCallId(), call.getToolName(), msg));
                     continue;
-                }
-
-                if (perm.type() == PermissionResult.Type.WARN
-                    && !confirmation.isAutoApproveMode()) {
-                    ToolExecution exec = new ToolExecution(
-                            call.getToolName(),
-                            call.getDescription() != null ? call.getDescription() : "执行工具操作",
-                            call.getParameters(),
-                            true);
-                    ToolExecutionConfirmation.ActionType action = confirmation.askConfirmationWithOptions(exec);
-                    if (action == ToolExecutionConfirmation.ActionType.NO) {
-                        context.getUi().displayWarning("⏭️  已取消：" + describeTool(call));
-                        history.add(ChatMessage.toolResult(call.getProviderCallId(), call.getToolName(),
-                                "用户拒绝执行该工具。"));
-                        stop = true;
-                        continue;
-                    }
                 }
 
                 // 执行并把结果按 id 配对写回 history

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,8 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tools.BaseTool;
-import com.thoughtcoding.tools.ToolDispatcher;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -96,6 +96,9 @@ public class AgentLoop {
             pendingToolCalls.clear();
             // 一轮模型响应（无新用户输入；用户消息与历史已在 history 中）
             context.getAiService().streamingChat(null, history, modelName);
+            // 空一行，避免与后续工具确认/结果挤在一起
+            context.getUi().getTerminal().writer().println();
+            context.getUi().getTerminal().flush();
 
             if (pendingToolCalls.isEmpty()) {
                 break; // 模型只产出文本 → 自然终止
@@ -132,6 +135,8 @@ public class AgentLoop {
                 // 执行并把结果按 id 配对写回 history
                 ToolResult result = toolDispatcher.dispatch(call);
                 displayNativeToolResult(call, result);
+                // 工具结果显示后空一行，避免与下一轮 AI 流式文本挤在同一区域
+                context.getUi().getTerminal().writer().println();
                 String resultText = result.isSuccess()
                         ? (result.getOutput() == null || result.getOutput().isBlank()
                             ? "执行成功（无输出）。" : result.getOutput())

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -25,7 +25,7 @@ public class AgentLoop {
     private final String sessionId;
     private final String modelName;
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
-    private final ToolDispatcher toolDispatcher;           // 工具执行唯一收口（沙箱插桩点）
+    private final ToolDispatcher toolDispatcher;
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,7 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.PermissionGate;
+import com.thoughtcoding.tool.PermissionResult;
 import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ import java.util.List;
  * AI 交互的核心循环。
  *
  * 基于 langchain4j 原生 function calling 的多轮 agentic 循环：
- * 用户输入 → 模型响应（可能请求工具）→ 执行工具（仅写/执行类确认）→ 结果按 id 配对回喂 →
+ * 用户输入 → 模型响应（可能请求工具）→ 权限检查 → 执行工具（写/执行类 + 越界只读类确认）→ 结果按 id 配对回喂 →
  * 无新输入再问模型，直到模型不再请求工具、用户取消、或达到 maxToolIterations。
  */
 public class AgentLoop {
@@ -115,8 +116,19 @@ public class AgentLoop {
                     continue;
                 }
 
-                // 仅写/执行类需要确认（除非处于自动批准模式）
-                if (requiresConfirmation(call) && !confirmation.isAutoApproveMode()) {
+                // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
+                PermissionResult perm = PermissionGate.check(
+                    call.getToolName(), call.getParameters());
+
+                if (perm.type() == PermissionResult.Type.DENY) {
+                    context.getUi().displayError(perm.message());
+                    history.add(ChatMessage.toolResult(
+                        call.getProviderCallId(), call.getToolName(), perm.message()));
+                    continue;
+                }
+
+                if (perm.type() == PermissionResult.Type.WARN
+                    && !confirmation.isAutoApproveMode()) {
                     ToolExecution exec = new ToolExecution(
                             call.getToolName(),
                             call.getDescription() != null ? call.getDescription() : "执行工具操作",
@@ -157,17 +169,6 @@ public class AgentLoop {
                 break;
             }
         }
-    }
-
-    /** 写/执行类工具需要确认；只读工具（由工具自身 isReadOnly() 声明）静默放行。 */
-    private boolean requiresConfirmation(ToolCall call) {
-        String name = call.getToolName();
-        if (name == null) {
-            return true;
-        }
-        BaseTool tool = context.getToolRegistry().getTool(name);
-        // 未知/MCP 工具（未声明只读）默认需确认；工具自身声明 isReadOnly 则静默放行。
-        return tool == null || !tool.isReadOnly();
     }
 
     private String describeTool(ToolCall call) {

--- a/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
+++ b/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
@@ -1,6 +1,6 @@
 package com.thoughtcoding.core;
 
-import com.thoughtcoding.tools.BashTool;
+import com.thoughtcoding.tool.tools.BashTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 import com.thoughtcoding.model.ToolResult;
 

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -10,12 +10,13 @@ import com.thoughtcoding.service.ContextManager;
 import com.thoughtcoding.service.LangChainService;
 import com.thoughtcoding.service.PerformanceMonitor;
 import com.thoughtcoding.service.SessionService;
-import com.thoughtcoding.tools.*;
-import com.thoughtcoding.tools.BashTool;
-import com.thoughtcoding.tools.EditTool;
-import com.thoughtcoding.tools.ReadTool;
-import com.thoughtcoding.tools.WriteTool;
-import com.thoughtcoding.tools.GlobTool;
+import com.thoughtcoding.tool.*;
+import com.thoughtcoding.tool.tools.BashTool;
+import com.thoughtcoding.tool.tools.EditTool;
+import com.thoughtcoding.tool.tools.GlobTool;
+import com.thoughtcoding.tool.tools.ReadTool;
+import com.thoughtcoding.tool.Sandbox;
+import com.thoughtcoding.tool.tools.WriteTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 
 import java.util.ArrayList;
@@ -67,6 +68,9 @@ public class ThoughtCodingContext {
         configManager.initialize("config.yaml");
         AppConfig appConfig = configManager.getAppConfig();
         MCPConfig mcpConfig = configManager.getMCPConfig();
+
+        // 初始化沙箱（以启动时的工作目录为 workspace 根）
+        Sandbox.init(System.getProperty("user.dir"));
 
         // 能力层初始化,创建工具注册表
         ToolRegistry toolRegistry = new ToolRegistry(appConfig);

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -16,6 +16,7 @@ import com.thoughtcoding.tool.tools.EditTool;
 import com.thoughtcoding.tool.tools.GlobTool;
 import com.thoughtcoding.tool.tools.ReadTool;
 import com.thoughtcoding.tool.Sandbox;
+import com.thoughtcoding.tool.tools.TodoWriteTool;
 import com.thoughtcoding.tool.tools.WriteTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 
@@ -99,6 +100,9 @@ public class ThoughtCodingContext {
         if (appConfig.getTools().getGlob().isEnabled()) {
             toolRegistry.register(new GlobTool(appConfig));
         }
+
+        // 规划工具（纯内存、无副作用），始终可用，无需 config 开关
+        toolRegistry.register(new TodoWriteTool());
 
         // 🔥 初始化 MCP 服务（如果启用）
         if (mcpConfig != null && mcpConfig.isEnabled()) {

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,10 +1,9 @@
 package com.thoughtcoding.exception;
 
 /**
- * 沙箱路径越界异常。
+ * 沙箱路径异常。
  *
- * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
- * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ * 由 {@link com.thoughtcoding.tool.Sandbox#resolve} 在路径为空白时抛出。
  */
 public class WorkspaceSecurityException extends RuntimeException {
 

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,0 +1,14 @@
+package com.thoughtcoding.exception;
+
+/**
+ * 沙箱路径越界异常。
+ *
+ * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
+ * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ */
+public class WorkspaceSecurityException extends RuntimeException {
+
+    public WorkspaceSecurityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/Hook.java
+++ b/src/main/java/com/thoughtcoding/hook/Hook.java
@@ -1,0 +1,18 @@
+package com.thoughtcoding.hook;
+
+/**
+ * Hook 动作。给定时机触发时执行，返回 {@link HookResult} 决定是否放行/阻断/续跑。
+ *
+ * <p>约定：动作应尽量轻量、避免抛异常；如需阻断请返回 {@link HookResult#block}，
+ * 注册表会捕获未受检异常并降级为放行（不因单个 hook 崩溃而中断主循环）。
+ */
+@FunctionalInterface
+public interface Hook {
+
+    HookResult execute(HookContext context) throws Exception;
+
+    /** 展示名，用于日志/调试；默认取实现类简单名。 */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookContext.java
+++ b/src/main/java/com/thoughtcoding/hook/HookContext.java
@@ -1,0 +1,95 @@
+package com.thoughtcoding.hook;
+
+import com.thoughtcoding.core.ThoughtCodingContext;
+import com.thoughtcoding.model.ChatMessage;
+import com.thoughtcoding.model.ToolCall;
+import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.ui.ThoughtCodingUI;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Hook 执行时传递给各动作的上下文载体。
+ *
+ * <p>不同时机携带不同字段（多数字段可空），动作按需读取/改写：
+ * <ul>
+ *   <li>{@link HookType#USER_PROMPT_SUBMIT}：读写 {@link #prompt}，可通过 {@link #injectContext} 注入附加上下文</li>
+ *   <li>{@link HookType#PRE_TOOL_USE}：读 {@link #toolCall}</li>
+ *   <li>{@link HookType#POST_TOOL_USE}：读 {@link #toolCall} 与 {@link #toolResult}</li>
+ *   <li>{@link HookType#STOP}：读 {@link #history}</li>
+ * </ul>
+ *
+ * <p>通过 {@link #getContext()} 访问应用上下文（UI/配置/会话/工具注册表等），
+ * {@link #getUi()} 为其中最常用的输出能力提供快捷方式。
+ */
+public class HookContext {
+
+    private final HookType type;
+    private final ThoughtCodingContext context;
+    private final List<ChatMessage> history;
+
+    // USER_PROMPT_SUBMIT：可被动作改写的用户输入
+    private String prompt;
+    // USER_PROMPT_SUBMIT：动作追加的附加上下文（进入 LLM 前拼接）
+    private final List<String> injectedContext = new ArrayList<>();
+
+    // PRE/POST_TOOL_USE：当前工具调用
+    private final ToolCall toolCall;
+    // POST_TOOL_USE：工具执行结果
+    private final ToolResult toolResult;
+
+    private HookContext(HookType type, ThoughtCodingContext context, List<ChatMessage> history,
+                        String prompt, ToolCall toolCall, ToolResult toolResult) {
+        this.type = type;
+        this.context = context;
+        this.history = history;
+        this.prompt = prompt;
+        this.toolCall = toolCall;
+        this.toolResult = toolResult;
+    }
+
+    public static HookContext forUserPrompt(ThoughtCodingContext context, List<ChatMessage> history, String prompt) {
+        return new HookContext(HookType.USER_PROMPT_SUBMIT, context, history, prompt, null, null);
+    }
+
+    public static HookContext forPreTool(ThoughtCodingContext context, List<ChatMessage> history, ToolCall call) {
+        return new HookContext(HookType.PRE_TOOL_USE, context, history, null, call, null);
+    }
+
+    public static HookContext forPostTool(ThoughtCodingContext context, List<ChatMessage> history,
+                                          ToolCall call, ToolResult result) {
+        return new HookContext(HookType.POST_TOOL_USE, context, history, null, call, result);
+    }
+
+    public static HookContext forStop(ThoughtCodingContext context, List<ChatMessage> history) {
+        return new HookContext(HookType.STOP, context, history, null, null, null);
+    }
+
+    public HookType getType() { return type; }
+
+    /** 应用上下文：UI / 配置 / 会话 / 工具注册表等。 */
+    public ThoughtCodingContext getContext() { return context; }
+
+    /** 最常用的输出能力快捷方式，等价于 {@code getContext().getUi()}。 */
+    public ThoughtCodingUI getUi() { return context != null ? context.getUi() : null; }
+
+    public List<ChatMessage> getHistory() { return history; }
+
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+
+    public ToolCall getToolCall() { return toolCall; }
+    public ToolResult getToolResult() { return toolResult; }
+
+    /** 注入附加上下文（USER_PROMPT_SUBMIT 时机专用）。 */
+    public void injectContext(String context) {
+        if (context != null && !context.isBlank()) {
+            injectedContext.add(context);
+        }
+    }
+
+    public List<String> getInjectedContext() {
+        return new ArrayList<>(injectedContext);
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookRegistry.java
+++ b/src/main/java/com/thoughtcoding/hook/HookRegistry.java
@@ -52,7 +52,7 @@ public class HookRegistry {
     public HookResult fire(HookContext context) {
         List<Entry> chain = hooks.getOrDefault(context.getType(), Collections.emptyList());
         if (chain.isEmpty()) {
-            return HookResult.PROCEED; // 空链：不打印、不做任何事
+            return HookResult.proceed(); // 空链：不打印、不做任何事
         }
 
         // 打印本时机注册的动作：Hook(a、b、c)，走项目 UI 而非裸 System.out
@@ -81,7 +81,7 @@ public class HookRegistry {
                 return result; // 阻断 / 强制续跑 → 提前终止串行链
             }
         }
-        return HookResult.PROCEED;
+        return HookResult.proceed();
     }
 
     /** 某时机已注册的动作数量（便于调试/测试）。 */

--- a/src/main/java/com/thoughtcoding/hook/HookRegistry.java
+++ b/src/main/java/com/thoughtcoding/hook/HookRegistry.java
@@ -1,0 +1,91 @@
+package com.thoughtcoding.hook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hook 注册表 —— Hook 系统的统一管理者，仿照 {@code ToolRegistry} 的注册表理念。
+ *
+ * <p>构造时即为 {@link HookType} 的四种时机各建立一条有序动作链；
+ * {@link #register} 按顺序追加动作，{@link #fire} 在对应时机 <b>串行</b> 触发。
+ *
+ * <p>串行语义：
+ * <ul>
+ *   <li>任一动作返回 {@link HookResult.Decision#BLOCK} → 立即终止本链，返回该阻断结果；</li>
+ *   <li>STOP 时机任一动作返回 {@link HookResult.Decision#CONTINUE_LOOP} → 记为「强制续跑」并终止本链；</li>
+ *   <li>动作抛出异常 → 捕获并降级为放行，不中断主循环。</li>
+ * </ul>
+ */
+public class HookRegistry {
+
+    /** 动作及其展示名的绑定。 */
+    private record Entry(String name, Hook hook) {}
+
+    private final Map<HookType, List<Entry>> hooks = new EnumMap<>(HookType.class);
+
+    public HookRegistry() {
+        // 一开始先注册（建立）四种 hook 时机
+        for (HookType type : HookType.values()) {
+            hooks.put(type, new ArrayList<>());
+        }
+    }
+
+    /** 向指定时机追加一个动作，返回自身以便链式注册。 */
+    public HookRegistry register(HookType type, String name, Hook hook) {
+        if (type == null || hook == null) return this;
+        hooks.get(type).add(new Entry(name != null ? name : hook.name(), hook));
+        return this;
+    }
+
+    public HookRegistry register(HookType type, Hook hook) {
+        return register(type, hook.name(), hook);
+    }
+
+    /**
+     * 在指定时机串行触发所有动作。
+     *
+     * @return 聚合结果：命中 BLOCK 则返回该阻断；STOP 命中续跑则返回 CONTINUE_LOOP；否则 PROCEED。
+     */
+    public HookResult fire(HookContext context) {
+        List<Entry> chain = hooks.getOrDefault(context.getType(), Collections.emptyList());
+        if (chain.isEmpty()) {
+            return HookResult.PROCEED; // 空链：不打印、不做任何事
+        }
+
+        // 打印本时机注册的动作：Hook(a、b、c)，走项目 UI 而非裸 System.out
+        StringBuilder names = new StringBuilder();
+        for (Entry entry : chain) {
+            if (names.length() > 0) names.append("、");
+            names.append(entry.name());
+        }
+        if (context.getUi() != null) {
+            context.getUi().displayInfo(context.getType() + " Hook(" + names + ")");
+        }
+
+        for (Entry entry : chain) {
+            HookResult result;
+            try {
+                result = entry.hook().execute(context);
+            } catch (Exception e) {
+                // 单个 hook 崩溃不应中断主循环 —— 降级为放行
+                System.err.println("⚠️ Hook 执行异常 [" + context.getType() + "/" + entry.name()
+                        + "]: " + e.getMessage());
+                continue;
+            }
+            if (result == null) continue;
+
+            if (result.isBlocked() || result.isContinueLoop()) {
+                return result; // 阻断 / 强制续跑 → 提前终止串行链
+            }
+        }
+        return HookResult.PROCEED;
+    }
+
+    /** 某时机已注册的动作数量（便于调试/测试）。 */
+    public int count(HookType type) {
+        return hooks.getOrDefault(type, Collections.emptyList()).size();
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookResult.java
+++ b/src/main/java/com/thoughtcoding/hook/HookResult.java
@@ -1,0 +1,35 @@
+package com.thoughtcoding.hook;
+
+/**
+ * 单个 Hook 动作的执行结果。
+ *
+ * <pre>
+ *   proceed()          → 继续执行后续动作 / 放行本次操作
+ *   block(msg)         → 阻断：串行链路提前终止，本次操作被拒绝（PreToolUse/UserPromptSubmit 生效）
+ *   continueLoop(msg)  → STOP 时机专用：要求循环强制续跑，不退出
+ * </pre>
+ */
+public record HookResult(Decision decision, String message) {
+
+    public enum Decision {
+        /** 放行，继续后续动作。 */
+        PROCEED,
+        /** 阻断当前操作并终止本时机的后续动作。 */
+        BLOCK,
+        /** STOP 时机：阻止退出、强制续跑。 */
+        CONTINUE_LOOP
+    }
+
+    public static final HookResult PROCEED = new HookResult(Decision.PROCEED, null);
+
+    public static HookResult block(String message) {
+        return new HookResult(Decision.BLOCK, message);
+    }
+
+    public static HookResult continueLoop(String message) {
+        return new HookResult(Decision.CONTINUE_LOOP, message);
+    }
+
+    public boolean isBlocked() { return decision == Decision.BLOCK; }
+    public boolean isContinueLoop() { return decision == Decision.CONTINUE_LOOP; }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookResult.java
+++ b/src/main/java/com/thoughtcoding/hook/HookResult.java
@@ -20,7 +20,9 @@ public record HookResult(Decision decision, String message) {
         CONTINUE_LOOP
     }
 
-    public static final HookResult PROCEED = new HookResult(Decision.PROCEED, null);
+    public static HookResult proceed() {
+        return new HookResult(Decision.PROCEED, null);
+    }
 
     public static HookResult block(String message) {
         return new HookResult(Decision.BLOCK, message);

--- a/src/main/java/com/thoughtcoding/hook/HookType.java
+++ b/src/main/java/com/thoughtcoding/hook/HookType.java
@@ -1,0 +1,20 @@
+package com.thoughtcoding.hook;
+
+/**
+ * Hook 触发时机。
+ *
+ * <pre>
+ *   USER_PROMPT_SUBMIT  用户输入提交后、进入 LLM 前  —— 输入验证、注入上下文
+ *   PRE_TOOL_USE        工具执行前                  —— 权限检查、日志记录
+ *   POST_TOOL_USE       工具执行后                  —— 副作用（自动 git add 等）、输出检查
+ *   STOP                循环即将退出时              —— 收尾清理（可强制续跑）
+ * </pre>
+ *
+ * 同一时机内注册的多个动作按注册顺序 <b>串行</b> 执行。
+ */
+public enum HookType {
+    USER_PROMPT_SUBMIT,
+    PRE_TOOL_USE,
+    POST_TOOL_USE,
+    STOP
+}

--- a/src/main/java/com/thoughtcoding/mcp/MCPService.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPService.java
@@ -3,8 +3,7 @@ package com.thoughtcoding.mcp;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.mcp.model.MCPTool;
 import com.thoughtcoding.model.ToolResult;
-import com.thoughtcoding.tools.BaseTool; // 使用你的 BaseTool 基类
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool; // 使用你的 BaseTool 基类
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
@@ -1,9 +1,7 @@
 package com.thoughtcoding.mcp;
 
 import com.thoughtcoding.config.MCPConfig;
-import com.thoughtcoding.config.MCPServerConfig;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -171,7 +171,6 @@ public class LangChainService implements AIService {
                             history.add(new ChatMessage("assistant", text));
                         }
                     }
-                    System.out.println();
                 } finally {
                     isGenerating = false;
                     shouldStop = false;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -4,7 +4,7 @@ import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolCallRef;
-import com.thoughtcoding.tools.ToolRegistry;
+import com.thoughtcoding.tool.ToolRegistry;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;

--- a/src/main/java/com/thoughtcoding/tool/BaseTool.java
+++ b/src/main/java/com/thoughtcoding/tool/BaseTool.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,0 +1,122 @@
+package com.thoughtcoding.tool;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 权限管道 —— AgentLoop 的唯一决策入口。
+ *
+ * <pre>
+ * 调用方式：
+ *   PermissionResult perm = PermissionGate.check(toolName, params);
+ *   if (perm.type() == DENY)  → 直接报错跳过
+ *   if (perm.type() == WARN)  → 弹确认
+ *   // ALLOW → 静默放行
+ * </pre>
+ *
+ * 决策规则：
+ *   read / glob  → 路径越界则 WARN，否则 ALLOW
+ *   write / edit → 固定 WARN
+ *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
+ *   未知工具      → WARN
+ */
+public final class PermissionGate {
+
+    private PermissionGate() {}
+
+    // ═══════════════ Gate 1: 硬拒绝列表 ═══════════════
+
+    private static final List<String> BASH_DENY_PATTERNS = List.of(
+        "rm -rf /", "sudo ", "shutdown", "reboot", "mkfs",
+        "dd if=", "> /dev/sda", "format ", "del /f /s", "rd /s /q"
+    );
+
+    private static PermissionResult checkBashDeny(String command) {
+        if (command == null || command.isBlank()) return null;
+        String lower = command.toLowerCase();
+        for (String pattern : BASH_DENY_PATTERNS) {
+            if (lower.contains(pattern)) {
+                return PermissionResult.deny(
+                    "⛔ 命令被阻止: '" + pattern + "' 在拒绝列表中");
+            }
+        }
+        return null;
+    }
+
+    // ═══════════════ Gate 2: 规则匹配 ═══════════════
+
+    // ── read / glob：路径越界才确认 ──
+    private static PermissionResult checkReadPath(Map<String, Object> params) {
+        String pathStr = paramString(params, "path");
+        if (pathStr == null || pathStr.isBlank()) return PermissionResult.ALLOW;
+
+        try {
+            Path resolved = Sandbox.resolve(pathStr);
+            if (!Sandbox.isWithinWorkspace(resolved)) {
+                return PermissionResult.warn(
+                    "⚠️ 路径在 workspace 之外: " + resolved);
+            }
+        } catch (Exception ignored) {
+            // 解析失败不报 warning
+        }
+        return PermissionResult.ALLOW;
+    }
+
+    // ── bash：先过 Gate 1 拒绝列表，再追加危险模式提示 ──
+    private static PermissionResult checkBash(Map<String, Object> params) {
+        String command = paramString(params, "command");
+
+        // Gate 1: 硬拒绝
+        PermissionResult deny = checkBashDeny(command);
+        if (deny != null) return deny;
+
+        // 固定确认，有危险模式则追加提示
+        String extra = bashWarning(command);
+        return PermissionResult.warn(
+            "⚠️ 将执行 shell 命令" + (extra.isEmpty() ? "" : " —— " + extra));
+    }
+
+    /** 返回危险模式描述，无匹配返回空串。 */
+    private static String bashWarning(String command) {
+        if (command == null || command.isBlank()) return "";
+        String lower = command.toLowerCase();
+
+        if (lower.contains("rm ") || lower.contains("del "))
+            return "包含删除操作";
+        if (lower.contains("> /etc/") || lower.contains("> c:\\windows"))
+            return "写入系统目录";
+        if (lower.contains("chmod 777"))
+            return "修改关键权限";
+        if (lower.contains("git push --force") || lower.contains("git push -f"))
+            return "强制推送";
+        return "";
+    }
+
+    // ═══════════════ 入口 ═══════════════
+
+    /**
+     * 一次性权限决策。
+     *
+     * @return DENY → 拒绝执行；WARN → 弹确认；ALLOW → 静默放行
+     */
+    public static PermissionResult check(String toolName, Map<String, Object> params) {
+        if (toolName == null) return PermissionResult.warn("⚠️ 未知工具");
+
+        return switch (toolName) {
+            case "read", "glob" -> checkReadPath(params);
+            case "write"        -> PermissionResult.warn("⚠️ 将写入文件");
+            case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
+            case "bash"         -> checkBash(params);
+            default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
+        };
+    }
+
+    // ── 工具方法 ──
+
+    private static String paramString(Map<String, Object> params, String key) {
+        if (params == null) return null;
+        Object v = params.get(key);
+        return v == null ? null : v.toString();
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -21,6 +21,7 @@ import java.util.Map;
  *   read / glob  → 路径越界则 WARN，否则 ALLOW
  *   write / edit → 固定 WARN
  *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
+ *   todo_write   → ALLOW（纯内存规划工具，无副作用，静默放行）
  *   未知工具      → WARN
  */
 public final class PermissionGate {
@@ -111,6 +112,7 @@ public final class PermissionGate {
             case "write"        -> PermissionResult.warn("⚠️ 将写入文件");
             case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
             case "bash"         -> checkBash(params);
+            case "todo_write"   -> PermissionResult.ALLOW;
             default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
         };
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,5 +1,7 @@
 package com.thoughtcoding.tool;
 
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +59,9 @@ public final class PermissionGate {
                 return PermissionResult.warn(
                     "⚠️ 路径在 workspace 之外: " + resolved);
             }
-        } catch (Exception ignored) {
-            // 解析失败不报 warning
+        } catch (WorkspaceSecurityException e) {
+            // 路径为空/非法 → 交给工具侧报具体错误，权限不做拦截
+            return PermissionResult.ALLOW;
         }
         return PermissionResult.ALLOW;
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionHook.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionHook.java
@@ -1,0 +1,70 @@
+package com.thoughtcoding.tool;
+
+import com.thoughtcoding.core.ToolExecutionConfirmation;
+import com.thoughtcoding.hook.Hook;
+import com.thoughtcoding.hook.HookContext;
+import com.thoughtcoding.hook.HookResult;
+import com.thoughtcoding.model.ToolCall;
+import com.thoughtcoding.model.ToolExecution;
+
+/**
+ * 权限检查 Hook —— 将 {@link PermissionGate} 的检查逻辑注册到 PRE_TOOL_USE 时机。
+ *
+ * <p>执行流程：
+ * <ol>
+ *   <li>调用 {@link PermissionGate#check} 获取权限决策</li>
+ *   <li>DENY → {@link HookResult#block}，阻断工具执行</li>
+ *   <li>WARN → 非自动模式下弹出交互式确认框，用户拒绝则阻断</li>
+ *   <li>ALLOW / 自动模式 → 放行</li>
+ * </ol>
+ *
+ * <p>通过 Hook 机制收敛权限检查，使 {@code AgentLoop} 不再内联调用 {@code PermissionGate}，
+ * 统一走 {@code HookRegistry.fire(PRE_TOOL_USE)} 一个入口完成权限决策。
+ */
+public class PermissionHook implements Hook {
+
+    private final ToolExecutionConfirmation confirmation;
+
+    /**
+     * @param confirmation 交互式确认组件（由 AgentLoop 持有），用于 WARN 场景弹框
+     */
+    public PermissionHook(ToolExecutionConfirmation confirmation) {
+        this.confirmation = confirmation;
+    }
+
+    @Override
+    public HookResult execute(HookContext context) {
+        ToolCall call = context.getToolCall();
+        if (call == null) {
+            return HookResult.proceed();
+        }
+
+        PermissionResult perm = PermissionGate.check(call.getToolName(), call.getParameters());
+
+        // ── DENY：硬拒绝，直接阻断 ──
+        if (perm.type() == PermissionResult.Type.DENY) {
+            return HookResult.block(perm.message());
+        }
+
+        // ── WARN：非自动模式弹出确认框 ──
+        if (perm.type() == PermissionResult.Type.WARN && !confirmation.isAutoApproveMode()) {
+            ToolExecution exec = new ToolExecution(
+                    call.getToolName(),
+                    call.getDescription() != null ? call.getDescription() : "执行工具操作",
+                    call.getParameters(),
+                    true);
+            ToolExecutionConfirmation.ActionType action = confirmation.askConfirmationWithOptions(exec);
+            if (action == ToolExecutionConfirmation.ActionType.NO) {
+                return HookResult.block("用户拒绝执行该工具。");
+            }
+        }
+
+        // ── ALLOW / 自动模式放行 ──
+        return HookResult.proceed();
+    }
+
+    @Override
+    public String name() {
+        return "PermissionCheck";
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/PermissionResult.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionResult.java
@@ -1,0 +1,25 @@
+package com.thoughtcoding.tool;
+
+/**
+ * 权限检查结果。
+ *
+ * <pre>
+ *   deny  → 硬拒绝，不弹确认，直接报错
+ *   warn  → 命中规则，强制弹确认（即使只读工具也不例外）
+ *   allow → 正常走确认流程（该确认的工具会确认，只读工具静默放行）
+ * </pre>
+ */
+public record PermissionResult(Type type, String message) {
+
+    public enum Type { DENY, WARN, ALLOW }
+
+    public static PermissionResult deny(String message) {
+        return new PermissionResult(Type.DENY, message);
+    }
+
+    public static PermissionResult warn(String message) {
+        return new PermissionResult(Type.WARN, message);
+    }
+
+    public static final PermissionResult ALLOW = new PermissionResult(Type.ALLOW, null);
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -1,0 +1,114 @@
+package com.thoughtcoding.tool;
+
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ *
+ * <pre>
+ * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
+ * Path path = Sandbox.safePath(p.toString());
+ * </pre>
+ *
+ * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ */
+public final class Sandbox {
+
+    private static volatile Path workspaceRoot;
+
+    private Sandbox() {
+        // 工具类，禁止实例化
+    }
+
+    // ── 初始化 ──
+
+    /** 由 ThoughtCodingContext 初始化时调用一次。 */
+    public static void init(String workspacePath) {
+        Path raw = Paths.get(workspacePath).toAbsolutePath().normalize();
+        try {
+            workspaceRoot = raw.toRealPath();
+        } catch (Exception e) {
+            workspaceRoot = raw;
+        }
+    }
+
+    private static Path root() {
+        Path r = workspaceRoot;
+        if (r == null) {
+            // 未显式 init 时降级使用当前工作目录
+            r = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+            try {
+                r = r.toRealPath();
+            } catch (Exception ignored) {
+            }
+            workspaceRoot = r;
+        }
+        return r;
+    }
+
+    // ── 核心方法 ──
+
+    /**
+     * 校验并返回安全路径。
+     *
+     * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
+     * @return 已解析的绝对路径
+     * @throws WorkspaceSecurityException 路径在 workspace 之外
+     */
+    public static Path safePath(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            throw new WorkspaceSecurityException("路径不能为空");
+        }
+
+        Path root = root();
+        String expanded = expandUserHome(rawPath.trim());
+        Path target = root.resolve(expanded).normalize();
+
+        try {
+            Path real = target.toRealPath();
+            if (!real.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
+            }
+            return real;
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception fileNotExist) {
+            return validateParent(rawPath, target, root);
+        }
+    }
+
+    /** 文件不存在时，退而校验父目录。 */
+    private static Path validateParent(String rawPath, Path target, Path root) {
+        Path parent = target.getParent();
+        if (parent == null) {
+            throw new WorkspaceSecurityException(
+                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
+        }
+        try {
+            Path realParent = parent.toRealPath();
+            if (!realParent.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
+            }
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+        }
+        return target;
+    }
+
+    private static String expandUserHome(String path) {
+        if (path.equals("~")) {
+            return System.getProperty("user.home");
+        }
+        if (path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home") + path.substring(1);
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -6,14 +6,21 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ * 通用沙箱 —— 路径解析工具。
  *
  * <pre>
- * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
- * Path path = Sandbox.safePath(p.toString());
+ * // 工具内用法（只解析，不做权限决策）：
+ * Path path = Sandbox.resolve(p.toString());
+ *
+ * // PermissionGate 内用法（组合判断）：
+ * Path resolved = Sandbox.resolve(rawPath);
+ * if (!Sandbox.isWithinWorkspace(resolved)) {
+ *     return PermissionResult.warn("⚠️ 路径在 workspace 之外");
+ * }
  * </pre>
  *
- * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ * 权限决策由 PermissionGate 负责，AgentLoop 通过确认框交给用户选择，
+ * 默认 ask 而不是 deny。
  */
 public final class Sandbox {
 
@@ -49,57 +56,43 @@ public final class Sandbox {
         return r;
     }
 
-    // ── 核心方法 ──
+    // ── 路径解析（不做权限决策）──
 
     /**
-     * 校验并返回安全路径。
+     * 解析原始路径为绝对路径（展开 ~、相对于 workspace root 解析、normalize）。
+     * 不做越界检查——权限决策由上层 AgentLoop 负责。
      *
      * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
      * @return 已解析的绝对路径
-     * @throws WorkspaceSecurityException 路径在 workspace 之外
      */
-    public static Path safePath(String rawPath) {
+    public static Path resolve(String rawPath) {
         if (rawPath == null || rawPath.isBlank()) {
             throw new WorkspaceSecurityException("路径不能为空");
         }
 
         Path root = root();
         String expanded = expandUserHome(rawPath.trim());
-        Path target = root.resolve(expanded).normalize();
-
-        try {
-            Path real = target.toRealPath();
-            if (!real.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
-            }
-            return real;
-        } catch (WorkspaceSecurityException e) {
-            throw e;
-        } catch (Exception fileNotExist) {
-            return validateParent(rawPath, target, root);
-        }
+        return root.resolve(expanded).normalize();
     }
 
-    /** 文件不存在时，退而校验父目录。 */
-    private static Path validateParent(String rawPath, Path target, Path root) {
-        Path parent = target.getParent();
-        if (parent == null) {
-            throw new WorkspaceSecurityException(
-                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
-        }
+    /**
+     * 判断给定路径是否在 workspace 范围内。
+     */
+    public static boolean isWithinWorkspace(Path path) {
+        if (path == null) return false;
+        Path root = root();
         try {
-            Path realParent = parent.toRealPath();
-            if (!realParent.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
-            }
-        } catch (WorkspaceSecurityException e) {
-            throw e;
+            return path.toRealPath().startsWith(root);
         } catch (Exception e) {
-            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+            // 文件不存在时检查父目录
+            Path parent = path.getParent();
+            if (parent == null) return false;
+            try {
+                return parent.toRealPath().startsWith(root);
+            } catch (Exception ex) {
+                return false;
+            }
         }
-        return target;
     }
 
     private static String expandUserHome(String path) {

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.model.ToolCall;

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
- *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
+ * {@link #dispatch(ToolCall)}。权限检查由 AgentLoop 调用 {@link PermissionGate} 完成，
+ * 工具内部通过 {@link Sandbox#resolve} 只做路径解析，不做权限决策。
  */
 public class ToolDispatcher {
 
@@ -23,7 +23,7 @@ public class ToolDispatcher {
     }
 
     /**
-     * 执行一个工具调用：查表 → 序列化参数 →（沙箱检查）→ 执行。
+     * 执行一个工具调用：查表 → 序列化参数 → 执行。
      */
     public ToolResult dispatch(ToolCall call) {
         long start = System.currentTimeMillis();

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。这样未来的 workspace 沙箱只需在此一处插桩，即可以结构化的
- * (name, args) 看到 100% 的写/执行操作。
+ * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
+ *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
  */
 public class ToolDispatcher {
 
@@ -34,11 +34,6 @@ public class ToolDispatcher {
         }
 
         String argsJson = toJson(call.getParameters());
-
-        // 【沙箱插桩点】——下一任务在此插入 workspace 边界检查：
-        //   WriteGuard.check(call.getToolName(), call.getParameters())
-        // 对 write/edit 的 path、bash 的 command 做越界判定，
-        // 越界时直接 return ToolResult.error(...) 不进入 tool.execute。
 
         return tool.execute(argsJson);
     }

--- a/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.config.AppConfig;
 

--- a/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;

--- a/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.BufferedReader;
@@ -76,21 +77,31 @@ public class BashTool extends BaseTool {
 
             Process process = pb.start();
 
+            // 后台线程消费 stdout，避免主线程因 readLine 阻塞而无法触发超时
             StringBuilder output = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    output.append(line).append("\n");
+            Thread readerThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        output.append(line).append("\n");
+                    }
+                } catch (Exception ignored) {
+                    // 进程被 destroy 后流关闭，忽略
                 }
-            }
+            }, "bash-stdout-reader");
+            readerThread.start();
 
             boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
-                return error("命令超时（>" + timeoutSeconds + "s），已被终止:\n" + output.toString().trim(),
+                readerThread.interrupt();
+                return error("命令超时（>" + timeoutSeconds + "s），已被终止",
                         System.currentTimeMillis() - startTime);
             }
+
+            // 进程已退出，等 reader 线程收完最后几行输出
+            readerThread.join(5000);
 
             int exitCode = process.exitValue();
             String result = output.toString().trim();

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -84,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -56,7 +58,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -83,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -58,7 +57,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -85,8 +84,6 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
@@ -13,7 +14,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
+
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class GlobTool extends BaseTool {
             Object pathObj = params.get("path");
             String basePathStr = (pathObj == null || pathObj.toString().trim().isEmpty())
                     ? "." : pathObj.toString();
-            Path base = Paths.get(expandUserHome(basePathStr)).toAbsolutePath().normalize();
+            Path base = Sandbox.resolve(basePathStr);
 
             if (!Files.exists(base) || !Files.isDirectory(base)) {
                 return error("目录不存在: " + basePathStr, System.currentTimeMillis() - startTime);

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -130,6 +131,8 @@ public class GlobTool extends BaseTool {
             }
             return success(sb.toString().trim(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("查找失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +55,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -91,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -55,7 +54,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -93,8 +92,6 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -92,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/TodoWriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/TodoWriteTool.java
@@ -1,0 +1,152 @@
+package com.thoughtcoding.tool.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * todo_write 工具：创建并维护一个结构化的待办清单，用于规划、跟踪多步骤任务的进度。
+ *
+ * <p>它<b>不增加任何执行能力</b>——不读写文件、不跑命令，只是把模型给出的完整任务清单
+ * 存在会话内并渲染出来。它增加的是<b>规划能力</b>：让模型显式拆解大任务、跟踪进度、
+ * 上下文变长后也不会忘记待办。
+ *
+ * <p>状态保存在实例字段里：本工具在 {@code ToolRegistry} 中是单例，同一会话内多次调用
+ * 复用同一实例，因此 {@link #todos} 跨调用保留（等价于教学示例里的全局 {@code CURRENT_TODOS}）。
+ * {@code AgentLoop} 单线程顺序执行工具，无并发问题。模型每次都传【完整】列表，整体替换。
+ */
+public class TodoWriteTool extends BaseTool {
+
+    /** 合法状态值。 */
+    private static final List<String> STATUSES = List.of("pending", "in_progress", "completed");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 会话内的当前任务清单（跨调用保留）。 */
+    private final List<Todo> todos = new ArrayList<>();
+
+    /** 单个待办项：任务描述 + 状态。 */
+    private record Todo(String content, String status) {
+    }
+
+    public TodoWriteTool() {
+        super("todo_write",
+                "创建并维护一个结构化的待办清单，用于规划和跟踪多步骤任务的进度。\n"
+                + "何时使用：任务需要 3 个及以上步骤、较复杂/非平凡；用户一次给出多项任务；或你刚开始一项较大的任务时。\n"
+                + "用法：传入【完整】的 todos 列表（每次调用都要传全量，包含已完成项，而非只传增量）；"
+                + "每项含 content（任务描述，祈使句）与 status（pending/in_progress/completed）。\n"
+                + "规则：同一时刻最多只应有一个任务处于 in_progress；完成一项后立即标记为 completed，并把下一项置为 in_progress。\n"
+                + "注意：本工具只做规划、不执行任何实际操作，也不读写文件。简单的单步任务或纯咨询类问题无需使用。");
+    }
+
+    @Override
+    public JsonObjectSchema inputSchema() {
+        JsonObjectSchema item = JsonObjectSchema.builder()
+                .addStringProperty("content", "任务的简短描述（祈使句，如“实现登录接口”）")
+                .addEnumProperty("status", STATUSES, "任务状态：pending（待办）/ in_progress（进行中）/ completed（已完成）")
+                .required("content", "status")
+                .additionalProperties(false)
+                .build();
+
+        JsonArraySchema todosArray = JsonArraySchema.builder()
+                .description("完整的任务清单。每次调用都要传【全量】列表（含已完成项），而不是增量。")
+                .items(item)
+                .build();
+
+        return JsonObjectSchema.builder()
+                .addProperty("todos", todosArray)
+                .required("todos")
+                .additionalProperties(false)
+                .build();
+    }
+
+    /** 纯规划工具，无副作用，静默放行（权限见 PermissionGate 的 todo_write 分支）。 */
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ToolResult execute(String input) {
+        long startTime = System.currentTimeMillis();
+        try {
+            Map<String, Object> params = MAPPER.readValue(input, Map.class);
+
+            Object todosObj = params.get("todos");
+            if (!(todosObj instanceof List)) {
+                return error("todo_write 需要 'todos' 数组（完整任务清单）", System.currentTimeMillis() - startTime);
+            }
+
+            List<Object> raw = (List<Object>) todosObj;
+
+            // 空列表 → 清空清单
+            if (raw.isEmpty()) {
+                todos.clear();
+                return success("任务清单已清空。", System.currentTimeMillis() - startTime);
+            }
+
+            List<Todo> parsed = new ArrayList<>();
+            for (Object o : raw) {
+                if (!(o instanceof Map)) {
+                    continue;
+                }
+                Map<String, Object> item = (Map<String, Object>) o;
+
+                Object contentObj = item.get("content");
+                String content = contentObj == null ? "" : contentObj.toString().trim();
+                if (content.isEmpty()) {
+                    continue; // 跳过无 content 的无效项
+                }
+
+                Object statusObj = item.get("status");
+                String status = statusObj == null ? "" : statusObj.toString().trim().toLowerCase(Locale.ROOT);
+                if (!STATUSES.contains(status)) {
+                    status = "pending"; // 非法/缺失状态回退为 pending
+                }
+
+                parsed.add(new Todo(content, status));
+            }
+
+            if (parsed.isEmpty()) {
+                return error("没有有效的任务项（每项需包含非空 content）", System.currentTimeMillis() - startTime);
+            }
+
+            // 整体替换会话内清单
+            todos.clear();
+            todos.addAll(parsed);
+
+            return success(render(), System.currentTimeMillis() - startTime);
+
+        } catch (Exception e) {
+            return error("todo_write 参数解析失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
+        }
+    }
+
+    /** 把当前清单渲染为带图标的进度视图（既用于终端显示，也回喂给模型确认状态）。 */
+    private String render() {
+        long done = todos.stream().filter(t -> "completed".equals(t.status())).count();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("TodoList (").append(done).append('/').append(todos.size()).append(")\n");
+        for (Todo t : todos) {
+            sb.append("  ").append(icon(t.status())).append(' ').append(t.content()).append('\n');
+        }
+        return sb.toString().trim();
+    }
+
+    private static String icon(String status) {
+        return switch (status) {
+            case "completed" -> "✓";
+            case "in_progress" -> "▸";
+            default -> "○";
+        };
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -50,7 +49,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -59,8 +58,6 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -48,7 +50,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -57,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -58,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {


### PR DESCRIPTION
实现 TodoList 规划功能并注册进上下文

  变更类型

  - [x] 新功能 (feature)

  变更摘要

  3 files changed, +158 / -0。核心变更为：新增纯内存的 todo_write
  规划工具，让模型能显式拆解并跟踪多步骤任务，并将其注册进 ToolRegistry（始终可用、无需 config 开关），同时在
  PermissionGate 中为其配置静默放行分支。

  一、TodoWriteTool —— 任务规划工具

    问题：Agent 执行多步骤任务时缺乏显式规划能力。大任务未被拆解、上下文变长后容易遗忘待办进度，模型只能靠隐式记忆跟踪，
  易遗漏或重复执行。

    改动：
  - 新增 tool/tools/TodoWriteTool.java（152 行）：实现 todo_write 工具，创建并维护结构化待办清单（content +
  status：pending/in_progress/completed），仅存于会话、不读写文件、不跑命令
  - 全量替换语义：模型每次调用传【完整】列表（含已完成项）而非增量；实例持有 todos 字段跨调用保留（等价于教学示例全局
  CURRENT_TODOS）
  - 单例复用状态：ToolRegistry 中该工具为单例，AgentLoop 单线程顺序执行，无并发问题
  - 状态校验兜底：content 为空则跳过该项，status 非法/缺失回退为 pending，整列表无有效项则返回 error 不破坏会话状态
  - 只读放行：isReadOnly() 返回 true，render() 输出带状态图标（✓/▸/○）+ done/total
  计数的进度视图，既用于终端显示也回喂模型确认进度

  二、注册进上下文

    问题：新工具若散落到各处调用，可用性与治理难以统一。

    改动：
  - core/ThoughtCodingContext.java（+4）：在现有只读工具注册段（Glob 之后）追加 toolRegistry.register(new
  TodoWriteTool())，标注「纯内存、无副作用，始终可用，无需 config 开关」
  - tool/PermissionGate.java（+2）：switch 分支补充 case "todo_write" ->
  PermissionResult.ALLOW，并在类顶部注释区块登记该工具为「纯内存规划工具，无副作用，静默放行」，与 read/glob
  放行策略描述并列

  效果对比：

  之前：多步骤任务靠模型隐式记忆，长上下文易丢待办、重复执行
  之后：模型可显式拆解大任务（建清单）→ 跟踪单点 in_progress 推进 → 完成即标 completed，状态跨调用保留并可视化回显