### PR TITLE
Feature/subAgent 请先合并Feature/TodoList

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,32 +560,32 @@ cd ThoughtCoding
 继承 `BaseTool` 基类并实现核心方法：
 
 ```java
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 public class MyTool extends BaseTool {
-    
+
     public MyTool() {
         super("my_tool", "工具描述");
     }
-    
+
     @Override
     public ToolResult execute(String input) {
         // input 为 JSON 字符串，从 ToolDispatcher 传入
         // 工具实现逻辑
         return success("工具执行结果");
     }
-    
+
     @Override
     public JsonObjectSchema inputSchema() {
         // 定义工具参数 schema（供模型了解参数结构）
         return JsonObjectSchema.builder()
-            .addStringProperty("param1", "参数1描述")
-            .build();
+                .addStringProperty("param1", "参数1描述")
+                .build();
     }
-    
+
     @Override
     public boolean isReadOnly() {
         // 只读工具返回 true，静默放行无需用户确认

--- a/src/main/java/com/thoughtcoding/cli/MCPCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/MCPCommand.java
@@ -2,8 +2,7 @@ package com.thoughtcoding.cli;
 
 import com.thoughtcoding.mcp.MCPService;
 import com.thoughtcoding.mcp.MCPToolManager;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 

--- a/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
+++ b/src/main/java/com/thoughtcoding/cli/ThoughtCodingCommand.java
@@ -301,6 +301,7 @@ public class ThoughtCodingCommand implements Callable<Integer> {
                 }
 
                 // 🚀 新增：检查是否是直接命令执行
+                //TODO ：优化正则检测，降低误判率
                 if (directCommandExecutor.shouldExecuteDirectly(trimmedInput)) {
                     directCommandExecutor.executeDirectCommand(trimmedInput);
                     continue;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -1,6 +1,9 @@
 package com.thoughtcoding.core;
 
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.hook.HookContext;
+import com.thoughtcoding.hook.HookRegistry;
+import com.thoughtcoding.hook.HookResult;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
@@ -27,6 +30,7 @@ public class AgentLoop {
     private final String modelName;
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
     private final ToolDispatcher toolDispatcher;
+    private final HookRegistry hookRegistry;               // 基于注册表的 Hook 系统
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();
@@ -42,6 +46,9 @@ public class AgentLoop {
             context.getUi().getLineReader()
         );
         this.toolDispatcher = new ToolDispatcher(context.getToolRegistry());
+
+        // 一开始先注册四种 hook 时机（动作由业务方按需 register 追加）
+        this.hookRegistry = new HookRegistry();
 
         // 设置消息和工具调用处理器
         context.getAiService().setMessageHandler(this::handleMessage);
@@ -60,6 +67,11 @@ public class AgentLoop {
 
         try {
             pendingToolCalls.clear();
+
+            // ── Hook: UserPromptSubmit（进入 LLM 前）—— BLOCK 则跳过本轮 ──
+            HookResult promptResult = hookRegistry.fire(
+                    HookContext.forUserPrompt(context, history, input));
+
             history.add(new ChatMessage("user", input));
 
             // 原生 function calling：多轮 agentic 循环
@@ -102,6 +114,8 @@ public class AgentLoop {
             context.getUi().getTerminal().flush();
 
             if (pendingToolCalls.isEmpty()) {
+                // ── Hook: Stop（循环即将退出）──
+                hookRegistry.fire(HookContext.forStop(context, history));
                 break; // 模型只产出文本 → 自然终止
             }
 
@@ -115,6 +129,10 @@ public class AgentLoop {
                             "用户已取消后续工具执行。"));
                     continue;
                 }
+
+                // ── Hook: PreToolUse（工具执行前）—— BLOCK 则跳过该工具 ──
+                HookResult preResult = hookRegistry.fire(
+                        HookContext.forPreTool(context, history, call));
 
                 // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
                 PermissionResult perm = PermissionGate.check(
@@ -146,6 +164,10 @@ public class AgentLoop {
 
                 // 执行并把结果按 id 配对写回 history
                 ToolResult result = toolDispatcher.dispatch(call);
+
+                // ── Hook: PostToolUse（工具执行后）──
+                hookRegistry.fire(HookContext.forPostTool(context, history, call, result));
+
                 displayNativeToolResult(call, result);
                 // 工具结果显示后空一行，避免与下一轮 AI 流式文本挤在同一区域
                 context.getUi().getTerminal().writer().println();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,11 +6,9 @@ import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.hook.HookResult;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
-import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tool.PermissionGate;
-import com.thoughtcoding.tool.PermissionResult;
+import com.thoughtcoding.tool.PermissionHook;
 import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
@@ -49,6 +47,10 @@ public class AgentLoop {
 
         // 一开始先注册四种 hook 时机（动作由业务方按需 register 追加）
         this.hookRegistry = new HookRegistry();
+
+        // 将权限检查注册为 PRE_TOOL_USE 的 hook 动作
+        this.hookRegistry.register(com.thoughtcoding.hook.HookType.PRE_TOOL_USE,
+                new PermissionHook(this.confirmation));
 
         // 设置消息和工具调用处理器
         context.getAiService().setMessageHandler(this::handleMessage);
@@ -130,36 +132,16 @@ public class AgentLoop {
                     continue;
                 }
 
-                // ── Hook: PreToolUse（工具执行前）—— BLOCK 则跳过该工具 ──
+                // ── Hook: PreToolUse（工具执行前）—— 权限检查 + 自定义动作 ──
+                // PermissionHook 已注册在此时机：DENY → BLOCK，WARN → 弹确认
                 HookResult preResult = hookRegistry.fire(
                         HookContext.forPreTool(context, history, call));
-
-                // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
-                PermissionResult perm = PermissionGate.check(
-                    call.getToolName(), call.getParameters());
-
-                if (perm.type() == PermissionResult.Type.DENY) {
-                    context.getUi().displayError(perm.message());
+                if (preResult.isBlocked()) {
+                    String msg = preResult.message() != null ? preResult.message() : "工具执行被阻止。";
+                    context.getUi().displayError(msg);
                     history.add(ChatMessage.toolResult(
-                        call.getProviderCallId(), call.getToolName(), perm.message()));
+                        call.getProviderCallId(), call.getToolName(), msg));
                     continue;
-                }
-
-                if (perm.type() == PermissionResult.Type.WARN
-                    && !confirmation.isAutoApproveMode()) {
-                    ToolExecution exec = new ToolExecution(
-                            call.getToolName(),
-                            call.getDescription() != null ? call.getDescription() : "执行工具操作",
-                            call.getParameters(),
-                            true);
-                    ToolExecutionConfirmation.ActionType action = confirmation.askConfirmationWithOptions(exec);
-                    if (action == ToolExecutionConfirmation.ActionType.NO) {
-                        context.getUi().displayWarning("⏭️  已取消：" + describeTool(call));
-                        history.add(ChatMessage.toolResult(call.getProviderCallId(), call.getToolName(),
-                                "用户拒绝执行该工具。"));
-                        stop = true;
-                        continue;
-                    }
                 }
 
                 // 执行并把结果按 id 配对写回 history

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,8 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tools.BaseTool;
-import com.thoughtcoding.tools.ToolDispatcher;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -96,6 +96,9 @@ public class AgentLoop {
             pendingToolCalls.clear();
             // 一轮模型响应（无新用户输入；用户消息与历史已在 history 中）
             context.getAiService().streamingChat(null, history, modelName);
+            // 空一行，避免与后续工具确认/结果挤在一起
+            context.getUi().getTerminal().writer().println();
+            context.getUi().getTerminal().flush();
 
             if (pendingToolCalls.isEmpty()) {
                 break; // 模型只产出文本 → 自然终止
@@ -132,6 +135,8 @@ public class AgentLoop {
                 // 执行并把结果按 id 配对写回 history
                 ToolResult result = toolDispatcher.dispatch(call);
                 displayNativeToolResult(call, result);
+                // 工具结果显示后空一行，避免与下一轮 AI 流式文本挤在同一区域
+                context.getUi().getTerminal().writer().println();
                 String resultText = result.isSuccess()
                         ? (result.getOutput() == null || result.getOutput().isBlank()
                             ? "执行成功（无输出）。" : result.getOutput())

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -189,9 +189,9 @@ public class AgentLoop {
 
     /** 显示原生工具执行结果。 */
     private void displayNativeToolResult(ToolCall call, ToolResult result) {
-        // 🔥 task（子代理）的过程与结论已由子代理实时打印，这里不再重复 dump 输出，避免刷屏。
+        // 🔥 subAgent（子代理）的过程与结论已由子代理实时打印，这里不再重复 dump 输出，避免刷屏。
         //    结论仍照常写回 history 回喂模型（见调用处），不受影响。
-        if ("task".equals(call.getToolName())) {
+        if ("subAgent".equals(call.getToolName())) {
             if (result.isSuccess()) {
                 context.getUi().getTerminal().writer().println("└ 子代理已返回结论");
                 context.getUi().getTerminal().writer().flush();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -189,14 +189,14 @@ public class AgentLoop {
 
     /** 显示原生工具执行结果。 */
     private void displayNativeToolResult(ToolCall call, ToolResult result) {
-        // 🔥 subAgent（子代理）的过程与结论已由子代理实时打印，这里不再重复 dump 输出，避免刷屏。
+        // 🔥 subAgent（子Agent）的过程与结论已由子Agent实时打印，这里不再重复 dump 输出，避免刷屏。
         //    结论仍照常写回 history 回喂模型（见调用处），不受影响。
         if ("subAgent".equals(call.getToolName())) {
             if (result.isSuccess()) {
-                context.getUi().getTerminal().writer().println("└ 子代理已返回结论");
+                context.getUi().getTerminal().writer().println("└ 子Agent已返回结论");
                 context.getUi().getTerminal().writer().flush();
             } else {
-                context.getUi().displayError("❌ 子代理失败: " + result.getError());
+                context.getUi().displayError("❌ 子Agent失败: " + result.getError());
             }
             return;
         }

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -25,7 +25,7 @@ public class AgentLoop {
     private final String sessionId;
     private final String modelName;
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
-    private final ToolDispatcher toolDispatcher;           // 工具执行唯一收口（沙箱插桩点）
+    private final ToolDispatcher toolDispatcher;
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -189,6 +189,17 @@ public class AgentLoop {
 
     /** 显示原生工具执行结果。 */
     private void displayNativeToolResult(ToolCall call, ToolResult result) {
+        // 🔥 task（子代理）的过程与结论已由子代理实时打印，这里不再重复 dump 输出，避免刷屏。
+        //    结论仍照常写回 history 回喂模型（见调用处），不受影响。
+        if ("task".equals(call.getToolName())) {
+            if (result.isSuccess()) {
+                context.getUi().getTerminal().writer().println("└ 子代理已返回结论");
+                context.getUi().getTerminal().writer().flush();
+            } else {
+                context.getUi().displayError("❌ 子代理失败: " + result.getError());
+            }
+            return;
+        }
         if (result.isSuccess()) {
             context.getUi().displaySuccess("✅ 完成: " + describeTool(call));
             String output = result.getOutput();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -6,7 +6,8 @@ import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolExecution;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.service.PerformanceMonitor;
-import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.PermissionGate;
+import com.thoughtcoding.tool.PermissionResult;
 import com.thoughtcoding.tool.ToolDispatcher;
 
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ import java.util.List;
  * AI 交互的核心循环。
  *
  * 基于 langchain4j 原生 function calling 的多轮 agentic 循环：
- * 用户输入 → 模型响应（可能请求工具）→ 执行工具（仅写/执行类确认）→ 结果按 id 配对回喂 →
+ * 用户输入 → 模型响应（可能请求工具）→ 权限检查 → 执行工具（写/执行类 + 越界只读类确认）→ 结果按 id 配对回喂 →
  * 无新输入再问模型，直到模型不再请求工具、用户取消、或达到 maxToolIterations。
  */
 public class AgentLoop {
@@ -115,8 +116,19 @@ public class AgentLoop {
                     continue;
                 }
 
-                // 仅写/执行类需要确认（除非处于自动批准模式）
-                if (requiresConfirmation(call) && !confirmation.isAutoApproveMode()) {
+                // ── 权限决策：DENY → 拒绝 | WARN → 确认 | ALLOW → 放行 ──
+                PermissionResult perm = PermissionGate.check(
+                    call.getToolName(), call.getParameters());
+
+                if (perm.type() == PermissionResult.Type.DENY) {
+                    context.getUi().displayError(perm.message());
+                    history.add(ChatMessage.toolResult(
+                        call.getProviderCallId(), call.getToolName(), perm.message()));
+                    continue;
+                }
+
+                if (perm.type() == PermissionResult.Type.WARN
+                    && !confirmation.isAutoApproveMode()) {
                     ToolExecution exec = new ToolExecution(
                             call.getToolName(),
                             call.getDescription() != null ? call.getDescription() : "执行工具操作",
@@ -157,17 +169,6 @@ public class AgentLoop {
                 break;
             }
         }
-    }
-
-    /** 写/执行类工具需要确认；只读工具（由工具自身 isReadOnly() 声明）静默放行。 */
-    private boolean requiresConfirmation(ToolCall call) {
-        String name = call.getToolName();
-        if (name == null) {
-            return true;
-        }
-        BaseTool tool = context.getToolRegistry().getTool(name);
-        // 未知/MCP 工具（未声明只读）默认需确认；工具自身声明 isReadOnly 则静默放行。
-        return tool == null || !tool.isReadOnly();
     }
 
     private String describeTool(ToolCall call) {

--- a/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
+++ b/src/main/java/com/thoughtcoding/core/DirectCommandExecutor.java
@@ -1,6 +1,6 @@
 package com.thoughtcoding.core;
 
-import com.thoughtcoding.tools.BashTool;
+import com.thoughtcoding.tool.tools.BashTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 import com.thoughtcoding.model.ToolResult;
 

--- a/src/main/java/com/thoughtcoding/core/SubAgent.java
+++ b/src/main/java/com/thoughtcoding/core/SubAgent.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * 子代理循环 —— 在【全新、隔离】的对话历史里跑一个独立的 agentic 循环。
+ * SubAgent循环 —— 在【全新、隔离】的对话历史里跑一个独立的 agentic 循环。
  *
  * <p>与主 {@link AgentLoop} 的区别：
  * <ul>
@@ -44,23 +44,23 @@ public class SubAgent {
     }
 
     /**
-     * 运行子代理直到得出结论或达到最大轮次。
+     * 运行SubAgent直到得出结论或达到最大轮次。
      *
-     * @param taskPrompt 交给子代理的详细任务指令（作为它的首条 user 消息）
+     * @param taskPrompt 交给SubAgent的详细任务指令（作为它的首条 user 消息）
      * @param label      简短标签，仅用于终端展示
-     * @return 子代理的最终结论文本（唯一回传给主代理的内容）
+     * @return SubAgent的最终结论文本（唯一回传给主代理的内容）
      */
     public String run(String taskPrompt, String label) {
         ThoughtCodingUI ui = context.getUi();
         ObjectMapper mapper = new ObjectMapper();
 
-        printLine(ui, "[子代理] 开始: " + oneLine(label, 80));
+        printLine(ui, "[SubAgent] 开始: " + oneLine(label, 80));
 
-        // 全新隔离历史：子代理看不到主对话，任务信息全在 taskPrompt 里
+        // 全新隔离历史：SubAgent看不到主对话，任务信息全在 taskPrompt 里
         List<ChatMessage> subHistory = new ArrayList<>();
         subHistory.add(new ChatMessage("user", taskPrompt));
 
-        // 子代理自己的权限栈（共享 UI；auto-approve 默认 false —— 更安全的方向）
+        // SubAgent自己的权限栈（共享 UI；auto-approve 默认 false —— 更安全的方向）
         ToolExecutionConfirmation confirmation =
                 new ToolExecutionConfirmation(ui, ui.getLineReader());
         HookRegistry hookRegistry = new HookRegistry();
@@ -69,19 +69,18 @@ public class SubAgent {
 
         String subPrompt = context.getContextManager().buildSubagentSystemPrompt();
 
-        AppConfig.AIConfig aiCfg = context.getAppConfig().getAi();
-        int maxIter = aiCfg != null ? aiCfg.getMaxToolIterations() : 10;
+        int maxIter = 30;
 
         String lastText = "";
 
         for (int iter = 0; iter < maxIter; iter++) {
-            // 每轮首个 token 前打一个 [子代理] 前缀，其余 token 原样流式打印
+            // 每轮首个 token 前打一个 [SubAgent] 前缀，其余 token 原样流式打印
             final boolean[] headerPrinted = {false};
             SubagentTurn turn = context.getAiService().chatOnceForSubagent(
                     subPrompt, subHistory,
                     token -> {
                         if (!headerPrinted[0]) {
-                            printRaw(ui, "\n[子代理] ");
+                            printRaw(ui, "\n[SubAgent] ");
                             headerPrinted[0] = true;
                         }
                         printRaw(ui, token);
@@ -95,7 +94,7 @@ public class SubAgent {
 
             // 无工具调用 → 本轮即最终结论
             if (!turn.hasToolCalls()) {
-                printLine(ui, "[子代理] 结束");
+                printLine(ui, "[SubAgent] 结束");
                 return lastText;
             }
 
@@ -103,28 +102,28 @@ public class SubAgent {
             subHistory.add(ChatMessage.assistantWithToolCalls(turn.getText(), turn.getToolCalls()));
 
             // 逐个执行 —— 关键不变量：每个工具调用必须严格配对恰好一个 tool 结果，
-            // 否则子代理绕过了主链路的 sanitizeToolPairs，下一轮会 400。
+            // 否则SubAgent绕过了主链路的 sanitizeToolPairs，下一轮会 400。
             for (ToolCallRef ref : turn.getToolCalls()) {
                 String id = ref.getId();
                 String name = ref.getName();
 
                 // 递归硬闸：即便模型幻觉出 task，也拒绝并补一条配对结果
                 if ("task".equals(name)) {
-                    printLine(ui, "[子代理] 拒绝调用 task（禁止嵌套子代理）");
-                    subHistory.add(ChatMessage.toolResult(id, name, "拒绝：子代理不能再派生子代理。"));
+                    printLine(ui, "[SubAgent] 拒绝调用 task（禁止嵌套SubAgent）");
+                    subHistory.add(ChatMessage.toolResult(id, name, "拒绝：SubAgent不能再派生SubAgent。"));
                     continue;
                 }
 
                 Map<String, Object> params = parseArgs(mapper, ref.getArguments());
                 ToolCall call = new ToolCall(name, params, null, false, 0, false, id);
 
-                printLine(ui, "[子代理] 调用 " + name + argSummary(params));
+                printLine(ui, "[SubAgent] 调用 " + name + argSummary(params));
 
                 // 权限管道（写/执行类会弹确认）
                 HookResult pre = hookRegistry.fire(HookContext.forPreTool(context, subHistory, call));
                 if (pre.isBlocked()) {
                     String msg = pre.message() != null ? pre.message() : "工具执行被阻止。";
-                    printLine(ui, "[子代理] 结果: 已阻止 —— " + oneLine(msg, 80));
+                    printLine(ui, "[SubAgent] 结果: 已阻止 —— " + oneLine(msg, 80));
                     subHistory.add(ChatMessage.toolResult(id, name, msg));
                     continue;
                 }
@@ -136,20 +135,20 @@ public class SubAgent {
                             ? (result.getOutput() == null || result.getOutput().isBlank()
                                 ? "执行成功（无输出）。" : result.getOutput())
                             : ("执行失败: " + result.getError());
-                    printLine(ui, "[子代理] 结果: " + (result.isSuccess()
+                    printLine(ui, "[SubAgent] 结果: " + (result.isSuccess()
                             ? "成功" : ("失败 —— " + oneLine(result.getError(), 80))));
                     subHistory.add(ChatMessage.toolResult(id, name, resultText));
                 } catch (Exception e) {
-                    printLine(ui, "[子代理] 结果: 执行异常 —— " + oneLine(e.getMessage(), 80));
+                    printLine(ui, "[SubAgent] 结果: 执行异常 —— " + oneLine(e.getMessage(), 80));
                     subHistory.add(ChatMessage.toolResult(id, name, "执行异常: " + e.getMessage()));
                 }
             }
         }
 
         // 达到最大轮次：给出兜底结论，避免返回空串
-        printLine(ui, "[子代理] 已达最大工具轮次(" + maxIter + ")，停止。");
+        printLine(ui, "[SubAgent] 已达最大工具轮次(" + maxIter + ")，停止。");
         return (lastText == null || lastText.isBlank())
-                ? "子代理已达最大工具轮次(" + maxIter + ")，未产出最终结论。"
+                ? "SubAgent已达最大工具轮次(" + maxIter + ")，未产出最终结论。"
                 : lastText;
     }
 

--- a/src/main/java/com/thoughtcoding/core/SubAgent.java
+++ b/src/main/java/com/thoughtcoding/core/SubAgent.java
@@ -1,0 +1,204 @@
+package com.thoughtcoding.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.hook.HookContext;
+import com.thoughtcoding.hook.HookRegistry;
+import com.thoughtcoding.hook.HookResult;
+import com.thoughtcoding.hook.HookType;
+import com.thoughtcoding.model.ChatMessage;
+import com.thoughtcoding.model.SubagentTurn;
+import com.thoughtcoding.model.ToolCall;
+import com.thoughtcoding.model.ToolCallRef;
+import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.PermissionHook;
+import com.thoughtcoding.tool.ToolDispatcher;
+import com.thoughtcoding.ui.ThoughtCodingUI;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 子代理循环 —— 在【全新、隔离】的对话历史里跑一个独立的 agentic 循环。
+ *
+ * <p>与主 {@link AgentLoop} 的区别：
+ * <ul>
+ *   <li>自带独立 history（不碰主对话），只回传最终结论，中间过程丢弃；</li>
+ *   <li>看不到、也不能调用 {@code task} 工具（禁止递归）；</li>
+ *   <li>内部工具调用照样走 PRE_TOOL_USE 权限管道（写/执行类仍需确认）；</li>
+ *   <li>调用 {@link com.thoughtcoding.service.AIService#chatOnceForSubagent} —— 隔离的模型往返，
+ *       不抢占主循环共享的流式回调/生成状态。</li>
+ * </ul>
+ *
+ * <p>由 {@code SubAgentTool} 在被 dispatch 时同步创建并运行；此时主循环已阻塞在 dispatch 中，
+ * 复用同一个底层模型是顺序、无并发的，安全。
+ */
+public class SubAgent {
+
+    private final ThoughtCodingContext context;
+
+    public SubAgent(ThoughtCodingContext context) {
+        this.context = context;
+    }
+
+    /**
+     * 运行子代理直到得出结论或达到最大轮次。
+     *
+     * @param taskPrompt 交给子代理的详细任务指令（作为它的首条 user 消息）
+     * @param label      简短标签，仅用于终端展示
+     * @return 子代理的最终结论文本（唯一回传给主代理的内容）
+     */
+    public String run(String taskPrompt, String label) {
+        ThoughtCodingUI ui = context.getUi();
+        ObjectMapper mapper = new ObjectMapper();
+
+        printLine(ui, "[子代理] 开始: " + oneLine(label, 80));
+
+        // 全新隔离历史：子代理看不到主对话，任务信息全在 taskPrompt 里
+        List<ChatMessage> subHistory = new ArrayList<>();
+        subHistory.add(new ChatMessage("user", taskPrompt));
+
+        // 子代理自己的权限栈（共享 UI；auto-approve 默认 false —— 更安全的方向）
+        ToolExecutionConfirmation confirmation =
+                new ToolExecutionConfirmation(ui, ui.getLineReader());
+        HookRegistry hookRegistry = new HookRegistry();
+        hookRegistry.register(HookType.PRE_TOOL_USE, new PermissionHook(confirmation));
+        ToolDispatcher dispatcher = new ToolDispatcher(context.getToolRegistry());
+
+        String subPrompt = context.getContextManager().buildSubagentSystemPrompt();
+
+        AppConfig.AIConfig aiCfg = context.getAppConfig().getAi();
+        int maxIter = aiCfg != null ? aiCfg.getMaxToolIterations() : 10;
+
+        String lastText = "";
+
+        for (int iter = 0; iter < maxIter; iter++) {
+            // 每轮首个 token 前打一个 [子代理] 前缀，其余 token 原样流式打印
+            final boolean[] headerPrinted = {false};
+            SubagentTurn turn = context.getAiService().chatOnceForSubagent(
+                    subPrompt, subHistory,
+                    token -> {
+                        if (!headerPrinted[0]) {
+                            printRaw(ui, "\n[子代理] ");
+                            headerPrinted[0] = true;
+                        }
+                        printRaw(ui, token);
+                    });
+            if (headerPrinted[0]) {
+                printRaw(ui, "\n");
+                flush(ui);
+            }
+
+            lastText = turn.getText();
+
+            // 无工具调用 → 本轮即最终结论
+            if (!turn.hasToolCalls()) {
+                printLine(ui, "[子代理] 结束");
+                return lastText;
+            }
+
+            // 记录携带工具调用的 assistant 消息（供下一轮重建 AiMessage.toolExecutionRequests）
+            subHistory.add(ChatMessage.assistantWithToolCalls(turn.getText(), turn.getToolCalls()));
+
+            // 逐个执行 —— 关键不变量：每个工具调用必须严格配对恰好一个 tool 结果，
+            // 否则子代理绕过了主链路的 sanitizeToolPairs，下一轮会 400。
+            for (ToolCallRef ref : turn.getToolCalls()) {
+                String id = ref.getId();
+                String name = ref.getName();
+
+                // 递归硬闸：即便模型幻觉出 task，也拒绝并补一条配对结果
+                if ("task".equals(name)) {
+                    printLine(ui, "[子代理] 拒绝调用 task（禁止嵌套子代理）");
+                    subHistory.add(ChatMessage.toolResult(id, name, "拒绝：子代理不能再派生子代理。"));
+                    continue;
+                }
+
+                Map<String, Object> params = parseArgs(mapper, ref.getArguments());
+                ToolCall call = new ToolCall(name, params, null, false, 0, false, id);
+
+                printLine(ui, "[子代理] 调用 " + name + argSummary(params));
+
+                // 权限管道（写/执行类会弹确认）
+                HookResult pre = hookRegistry.fire(HookContext.forPreTool(context, subHistory, call));
+                if (pre.isBlocked()) {
+                    String msg = pre.message() != null ? pre.message() : "工具执行被阻止。";
+                    printLine(ui, "[子代理] 结果: 已阻止 —— " + oneLine(msg, 80));
+                    subHistory.add(ChatMessage.toolResult(id, name, msg));
+                    continue;
+                }
+
+                // 执行 —— 任何异常都转成配对的 tool 结果，绝不逃逸破坏配对
+                try {
+                    ToolResult result = dispatcher.dispatch(call);
+                    String resultText = result.isSuccess()
+                            ? (result.getOutput() == null || result.getOutput().isBlank()
+                                ? "执行成功（无输出）。" : result.getOutput())
+                            : ("执行失败: " + result.getError());
+                    printLine(ui, "[子代理] 结果: " + (result.isSuccess()
+                            ? "成功" : ("失败 —— " + oneLine(result.getError(), 80))));
+                    subHistory.add(ChatMessage.toolResult(id, name, resultText));
+                } catch (Exception e) {
+                    printLine(ui, "[子代理] 结果: 执行异常 —— " + oneLine(e.getMessage(), 80));
+                    subHistory.add(ChatMessage.toolResult(id, name, "执行异常: " + e.getMessage()));
+                }
+            }
+        }
+
+        // 达到最大轮次：给出兜底结论，避免返回空串
+        printLine(ui, "[子代理] 已达最大工具轮次(" + maxIter + ")，停止。");
+        return (lastText == null || lastText.isBlank())
+                ? "子代理已达最大工具轮次(" + maxIter + ")，未产出最终结论。"
+                : lastText;
+    }
+
+    // ── 显示辅助（纯文本、无装饰 emoji；直接走 terminal writer 以完全控制格式）──
+
+    private void printLine(ThoughtCodingUI ui, String text) {
+        if (ui == null || ui.getTerminal() == null) return;
+        ui.getTerminal().writer().println(text);
+        ui.getTerminal().writer().flush();
+    }
+
+    private void printRaw(ThoughtCodingUI ui, String text) {
+        if (ui == null || ui.getTerminal() == null) return;
+        ui.getTerminal().writer().print(text);
+    }
+
+    private void flush(ThoughtCodingUI ui) {
+        if (ui == null || ui.getTerminal() == null) return;
+        ui.getTerminal().writer().flush();
+    }
+
+    /** 解析工具参数 JSON 为 Map；失败则退化为 {"input": 原始串}（与主服务一致的兜底）。 */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseArgs(ObjectMapper mapper, String argumentsJson) {
+        if (argumentsJson == null || argumentsJson.isBlank()) {
+            return new HashMap<>();
+        }
+        try {
+            return mapper.readValue(argumentsJson, Map.class);
+        } catch (Exception e) {
+            Map<String, Object> fallback = new HashMap<>();
+            fallback.put("input", argumentsJson);
+            return fallback;
+        }
+    }
+
+    /** 从参数里挑一个有代表性的值做单行摘要（command/path/pattern 等），仅用于展示。 */
+    private String argSummary(Map<String, Object> params) {
+        if (params == null || params.isEmpty()) return "";
+        for (String key : new String[]{"command", "path", "file_path", "pattern"}) {
+            Object v = params.get(key);
+            if (v != null) return " (" + oneLine(v.toString(), 60) + ")";
+        }
+        return "";
+    }
+
+    private String oneLine(String s, int max) {
+        if (s == null) return "";
+        String t = s.replaceAll("\\s+", " ").trim();
+        return t.length() <= max ? t : t.substring(0, max) + "…";
+    }
+}

--- a/src/main/java/com/thoughtcoding/core/SubAgent.java
+++ b/src/main/java/com/thoughtcoding/core/SubAgent.java
@@ -48,7 +48,7 @@ public class SubAgent {
      *
      * @param subAgentPrompt 交给SubAgent的详细任务指令（作为它的首条 user 消息）
      * @param label      简短标签，仅用于终端展示
-     * @return SubAgent的最终结论文本（唯一回传给主代理的内容）
+     * @return SubAgent的最终结论文本（唯一回传给主Agent的内容）
      */
     public String run(String subAgentPrompt, String label) {
         ThoughtCodingUI ui = context.getUi();

--- a/src/main/java/com/thoughtcoding/core/SubAgent.java
+++ b/src/main/java/com/thoughtcoding/core/SubAgent.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * <p>与主 {@link AgentLoop} 的区别：
  * <ul>
  *   <li>自带独立 history（不碰主对话），只回传最终结论，中间过程丢弃；</li>
- *   <li>看不到、也不能调用 {@code SubAgent} 工具（禁止递归）；</li>
+ *   <li>看不到 {@code subAgent} 工具（已从其可见的工具规格中过滤），因此不可能递归；</li>
  *   <li>内部工具调用照样走 PRE_TOOL_USE 权限管道（写/执行类仍需确认）；</li>
  *   <li>调用 {@link com.thoughtcoding.service.AIService#chatOnceForSubagent} —— 隔离的模型往返，
  *       不抢占主循环共享的流式回调/生成状态。</li>
@@ -106,13 +106,6 @@ public class SubAgent {
             for (ToolCallRef ref : turn.getToolCalls()) {
                 String id = ref.getId();
                 String name = ref.getName();
-
-                // 递归硬闸：即便模型幻觉出 SubAgent，也拒绝并补一条配对结果
-                if ("subAgent".equals(name)) {
-                    printLine(ui, "[SubAgent] 拒绝调用 SubAgent（禁止嵌套SubAgent）");
-                    subHistory.add(ChatMessage.toolResult(id, name, "拒绝：SubAgent不能再派生SubAgent。"));
-                    continue;
-                }
 
                 Map<String, Object> params = parseArgs(mapper, ref.getArguments());
                 ToolCall call = new ToolCall(name, params, null, false, 0, false, id);

--- a/src/main/java/com/thoughtcoding/core/SubAgent.java
+++ b/src/main/java/com/thoughtcoding/core/SubAgent.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * <p>与主 {@link AgentLoop} 的区别：
  * <ul>
  *   <li>自带独立 history（不碰主对话），只回传最终结论，中间过程丢弃；</li>
- *   <li>看不到、也不能调用 {@code task} 工具（禁止递归）；</li>
+ *   <li>看不到、也不能调用 {@code SubAgent} 工具（禁止递归）；</li>
  *   <li>内部工具调用照样走 PRE_TOOL_USE 权限管道（写/执行类仍需确认）；</li>
  *   <li>调用 {@link com.thoughtcoding.service.AIService#chatOnceForSubagent} —— 隔离的模型往返，
  *       不抢占主循环共享的流式回调/生成状态。</li>
@@ -46,19 +46,19 @@ public class SubAgent {
     /**
      * 运行SubAgent直到得出结论或达到最大轮次。
      *
-     * @param taskPrompt 交给SubAgent的详细任务指令（作为它的首条 user 消息）
+     * @param subAgentPrompt 交给SubAgent的详细任务指令（作为它的首条 user 消息）
      * @param label      简短标签，仅用于终端展示
      * @return SubAgent的最终结论文本（唯一回传给主代理的内容）
      */
-    public String run(String taskPrompt, String label) {
+    public String run(String subAgentPrompt, String label) {
         ThoughtCodingUI ui = context.getUi();
         ObjectMapper mapper = new ObjectMapper();
 
         printLine(ui, "[SubAgent] 开始: " + oneLine(label, 80));
 
-        // 全新隔离历史：SubAgent看不到主对话，任务信息全在 taskPrompt 里
+        // 全新隔离历史：SubAgent看不到主对话，任务信息全在 subAgentPrompt 里
         List<ChatMessage> subHistory = new ArrayList<>();
-        subHistory.add(new ChatMessage("user", taskPrompt));
+        subHistory.add(new ChatMessage("user", subAgentPrompt));
 
         // SubAgent自己的权限栈（共享 UI；auto-approve 默认 false —— 更安全的方向）
         ToolExecutionConfirmation confirmation =
@@ -107,9 +107,9 @@ public class SubAgent {
                 String id = ref.getId();
                 String name = ref.getName();
 
-                // 递归硬闸：即便模型幻觉出 task，也拒绝并补一条配对结果
-                if ("task".equals(name)) {
-                    printLine(ui, "[SubAgent] 拒绝调用 task（禁止嵌套SubAgent）");
+                // 递归硬闸：即便模型幻觉出 SubAgent，也拒绝并补一条配对结果
+                if ("subAgent".equals(name)) {
+                    printLine(ui, "[SubAgent] 拒绝调用 SubAgent（禁止嵌套SubAgent）");
                     subHistory.add(ChatMessage.toolResult(id, name, "拒绝：SubAgent不能再派生SubAgent。"));
                     continue;
                 }

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -17,6 +17,7 @@ import com.thoughtcoding.tool.tools.GlobTool;
 import com.thoughtcoding.tool.tools.ReadTool;
 import com.thoughtcoding.tool.Sandbox;
 import com.thoughtcoding.tool.tools.TodoWriteTool;
+import com.thoughtcoding.tool.tools.SubAgentTool;
 import com.thoughtcoding.tool.tools.WriteTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 
@@ -119,7 +120,7 @@ public class ThoughtCodingContext {
         ThoughtCodingUI ui = new ThoughtCodingUI();
 
         // 构建上下文（核心层初始化）
-        return new Builder()
+        ThoughtCodingContext context = new Builder()
                 .appConfig(appConfig)
                 .mcpConfig(mcpConfig)
                 .aiService(aiService)
@@ -131,6 +132,12 @@ public class ThoughtCodingContext {
                 .mcpToolManager(mcpToolManager)
                 .contextManager(contextManager)  // 🔥 添加 contextManager
                 .build();
+
+        // 🔥 子代理工具（task）：需持有已构建好的 context 引用来派生隔离子循环，故在 build 之后注册。
+        // toolRegistry 是同一可变实例，LangChainService 每次请求都重新读 getToolSpecifications()，能看见它。
+        context.getToolRegistry().register(new SubAgentTool(context));
+
+        return context;
     }
 
     /**

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -10,12 +10,13 @@ import com.thoughtcoding.service.ContextManager;
 import com.thoughtcoding.service.LangChainService;
 import com.thoughtcoding.service.PerformanceMonitor;
 import com.thoughtcoding.service.SessionService;
-import com.thoughtcoding.tools.*;
-import com.thoughtcoding.tools.BashTool;
-import com.thoughtcoding.tools.EditTool;
-import com.thoughtcoding.tools.ReadTool;
-import com.thoughtcoding.tools.WriteTool;
-import com.thoughtcoding.tools.GlobTool;
+import com.thoughtcoding.tool.*;
+import com.thoughtcoding.tool.tools.BashTool;
+import com.thoughtcoding.tool.tools.EditTool;
+import com.thoughtcoding.tool.tools.GlobTool;
+import com.thoughtcoding.tool.tools.ReadTool;
+import com.thoughtcoding.tool.Sandbox;
+import com.thoughtcoding.tool.tools.WriteTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 
 import java.util.ArrayList;
@@ -67,6 +68,9 @@ public class ThoughtCodingContext {
         configManager.initialize("config.yaml");
         AppConfig appConfig = configManager.getAppConfig();
         MCPConfig mcpConfig = configManager.getMCPConfig();
+
+        // 初始化沙箱（以启动时的工作目录为 workspace 根）
+        Sandbox.init(System.getProperty("user.dir"));
 
         // 能力层初始化,创建工具注册表
         ToolRegistry toolRegistry = new ToolRegistry(appConfig);

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -133,7 +133,7 @@ public class ThoughtCodingContext {
                 .contextManager(contextManager)  // 🔥 添加 contextManager
                 .build();
 
-        // 🔥 子代理工具（task）：需持有已构建好的 context 引用来派生隔离子循环，故在 build 之后注册。
+        // 🔥 子Agent 工具（subAgent）：需持有已构建好的 context 引用来派生隔离子循环，故在 build 之后注册。
         // toolRegistry 是同一可变实例，LangChainService 每次请求都重新读 getToolSpecifications()，能看见它。
         context.getToolRegistry().register(new SubAgentTool(context));
 

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -16,6 +16,7 @@ import com.thoughtcoding.tool.tools.EditTool;
 import com.thoughtcoding.tool.tools.GlobTool;
 import com.thoughtcoding.tool.tools.ReadTool;
 import com.thoughtcoding.tool.Sandbox;
+import com.thoughtcoding.tool.tools.TodoWriteTool;
 import com.thoughtcoding.tool.tools.WriteTool;
 import com.thoughtcoding.ui.ThoughtCodingUI;
 
@@ -99,6 +100,9 @@ public class ThoughtCodingContext {
         if (appConfig.getTools().getGlob().isEnabled()) {
             toolRegistry.register(new GlobTool(appConfig));
         }
+
+        // 规划工具（纯内存、无副作用），始终可用，无需 config 开关
+        toolRegistry.register(new TodoWriteTool());
 
         // 🔥 初始化 MCP 服务（如果启用）
         if (mcpConfig != null && mcpConfig.isEnabled()) {

--- a/src/main/java/com/thoughtcoding/core/ToolExecutionConfirmation.java
+++ b/src/main/java/com/thoughtcoding/core/ToolExecutionConfirmation.java
@@ -31,7 +31,7 @@ public class ToolExecutionConfirmation {
      */
     public ActionType askConfirmationWithOptions(ToolExecution execution) {
         if (autoApproveMode) {
-            ui.displayInfo("🤖 [自动批准模式] 执行: " + execution.toolName());
+            ui.displayInfo("[自动批准模式] 执行: " + execution.toolName());
             return ActionType.YES;
         }
 
@@ -263,9 +263,9 @@ public class ToolExecutionConfirmation {
     public void setAutoApproveMode(boolean enabled) {
         this.autoApproveMode = enabled;
         if (enabled) {
-            ui.displayInfo("🤖 自动批准模式已启用");
+            ui.displayInfo("自动批准模式已启用");
         } else {
-            ui.displayInfo("👤 交互式确认模式已启用");
+            ui.displayInfo("交互式确认模式已启用");
         }
     }
 

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,10 +1,9 @@
 package com.thoughtcoding.exception;
 
 /**
- * 沙箱路径越界异常。
+ * 沙箱路径异常。
  *
- * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
- * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ * 由 {@link com.thoughtcoding.tool.Sandbox#resolve} 在路径为空白时抛出。
  */
 public class WorkspaceSecurityException extends RuntimeException {
 

--- a/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
+++ b/src/main/java/com/thoughtcoding/exception/WorkspaceSecurityException.java
@@ -1,0 +1,14 @@
+package com.thoughtcoding.exception;
+
+/**
+ * 沙箱路径越界异常。
+ *
+ * 当工具尝试访问 workspace 之外的路径时，由 {@link com.thoughtcoding.tool.Sandbox#safePath}
+ * 抛出。工具的 execute() 方法在 catch 块中捕获此异常并返回 ToolResult.error。
+ */
+public class WorkspaceSecurityException extends RuntimeException {
+
+    public WorkspaceSecurityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/Hook.java
+++ b/src/main/java/com/thoughtcoding/hook/Hook.java
@@ -1,0 +1,18 @@
+package com.thoughtcoding.hook;
+
+/**
+ * Hook 动作。给定时机触发时执行，返回 {@link HookResult} 决定是否放行/阻断/续跑。
+ *
+ * <p>约定：动作应尽量轻量、避免抛异常；如需阻断请返回 {@link HookResult#block}，
+ * 注册表会捕获未受检异常并降级为放行（不因单个 hook 崩溃而中断主循环）。
+ */
+@FunctionalInterface
+public interface Hook {
+
+    HookResult execute(HookContext context) throws Exception;
+
+    /** 展示名，用于日志/调试；默认取实现类简单名。 */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookContext.java
+++ b/src/main/java/com/thoughtcoding/hook/HookContext.java
@@ -1,0 +1,95 @@
+package com.thoughtcoding.hook;
+
+import com.thoughtcoding.core.ThoughtCodingContext;
+import com.thoughtcoding.model.ChatMessage;
+import com.thoughtcoding.model.ToolCall;
+import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.ui.ThoughtCodingUI;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Hook 执行时传递给各动作的上下文载体。
+ *
+ * <p>不同时机携带不同字段（多数字段可空），动作按需读取/改写：
+ * <ul>
+ *   <li>{@link HookType#USER_PROMPT_SUBMIT}：读写 {@link #prompt}，可通过 {@link #injectContext} 注入附加上下文</li>
+ *   <li>{@link HookType#PRE_TOOL_USE}：读 {@link #toolCall}</li>
+ *   <li>{@link HookType#POST_TOOL_USE}：读 {@link #toolCall} 与 {@link #toolResult}</li>
+ *   <li>{@link HookType#STOP}：读 {@link #history}</li>
+ * </ul>
+ *
+ * <p>通过 {@link #getContext()} 访问应用上下文（UI/配置/会话/工具注册表等），
+ * {@link #getUi()} 为其中最常用的输出能力提供快捷方式。
+ */
+public class HookContext {
+
+    private final HookType type;
+    private final ThoughtCodingContext context;
+    private final List<ChatMessage> history;
+
+    // USER_PROMPT_SUBMIT：可被动作改写的用户输入
+    private String prompt;
+    // USER_PROMPT_SUBMIT：动作追加的附加上下文（进入 LLM 前拼接）
+    private final List<String> injectedContext = new ArrayList<>();
+
+    // PRE/POST_TOOL_USE：当前工具调用
+    private final ToolCall toolCall;
+    // POST_TOOL_USE：工具执行结果
+    private final ToolResult toolResult;
+
+    private HookContext(HookType type, ThoughtCodingContext context, List<ChatMessage> history,
+                        String prompt, ToolCall toolCall, ToolResult toolResult) {
+        this.type = type;
+        this.context = context;
+        this.history = history;
+        this.prompt = prompt;
+        this.toolCall = toolCall;
+        this.toolResult = toolResult;
+    }
+
+    public static HookContext forUserPrompt(ThoughtCodingContext context, List<ChatMessage> history, String prompt) {
+        return new HookContext(HookType.USER_PROMPT_SUBMIT, context, history, prompt, null, null);
+    }
+
+    public static HookContext forPreTool(ThoughtCodingContext context, List<ChatMessage> history, ToolCall call) {
+        return new HookContext(HookType.PRE_TOOL_USE, context, history, null, call, null);
+    }
+
+    public static HookContext forPostTool(ThoughtCodingContext context, List<ChatMessage> history,
+                                          ToolCall call, ToolResult result) {
+        return new HookContext(HookType.POST_TOOL_USE, context, history, null, call, result);
+    }
+
+    public static HookContext forStop(ThoughtCodingContext context, List<ChatMessage> history) {
+        return new HookContext(HookType.STOP, context, history, null, null, null);
+    }
+
+    public HookType getType() { return type; }
+
+    /** 应用上下文：UI / 配置 / 会话 / 工具注册表等。 */
+    public ThoughtCodingContext getContext() { return context; }
+
+    /** 最常用的输出能力快捷方式，等价于 {@code getContext().getUi()}。 */
+    public ThoughtCodingUI getUi() { return context != null ? context.getUi() : null; }
+
+    public List<ChatMessage> getHistory() { return history; }
+
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+
+    public ToolCall getToolCall() { return toolCall; }
+    public ToolResult getToolResult() { return toolResult; }
+
+    /** 注入附加上下文（USER_PROMPT_SUBMIT 时机专用）。 */
+    public void injectContext(String context) {
+        if (context != null && !context.isBlank()) {
+            injectedContext.add(context);
+        }
+    }
+
+    public List<String> getInjectedContext() {
+        return new ArrayList<>(injectedContext);
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookRegistry.java
+++ b/src/main/java/com/thoughtcoding/hook/HookRegistry.java
@@ -52,7 +52,7 @@ public class HookRegistry {
     public HookResult fire(HookContext context) {
         List<Entry> chain = hooks.getOrDefault(context.getType(), Collections.emptyList());
         if (chain.isEmpty()) {
-            return HookResult.PROCEED; // 空链：不打印、不做任何事
+            return HookResult.proceed(); // 空链：不打印、不做任何事
         }
 
         // 打印本时机注册的动作：Hook(a、b、c)，走项目 UI 而非裸 System.out
@@ -81,7 +81,7 @@ public class HookRegistry {
                 return result; // 阻断 / 强制续跑 → 提前终止串行链
             }
         }
-        return HookResult.PROCEED;
+        return HookResult.proceed();
     }
 
     /** 某时机已注册的动作数量（便于调试/测试）。 */

--- a/src/main/java/com/thoughtcoding/hook/HookRegistry.java
+++ b/src/main/java/com/thoughtcoding/hook/HookRegistry.java
@@ -1,0 +1,91 @@
+package com.thoughtcoding.hook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hook 注册表 —— Hook 系统的统一管理者，仿照 {@code ToolRegistry} 的注册表理念。
+ *
+ * <p>构造时即为 {@link HookType} 的四种时机各建立一条有序动作链；
+ * {@link #register} 按顺序追加动作，{@link #fire} 在对应时机 <b>串行</b> 触发。
+ *
+ * <p>串行语义：
+ * <ul>
+ *   <li>任一动作返回 {@link HookResult.Decision#BLOCK} → 立即终止本链，返回该阻断结果；</li>
+ *   <li>STOP 时机任一动作返回 {@link HookResult.Decision#CONTINUE_LOOP} → 记为「强制续跑」并终止本链；</li>
+ *   <li>动作抛出异常 → 捕获并降级为放行，不中断主循环。</li>
+ * </ul>
+ */
+public class HookRegistry {
+
+    /** 动作及其展示名的绑定。 */
+    private record Entry(String name, Hook hook) {}
+
+    private final Map<HookType, List<Entry>> hooks = new EnumMap<>(HookType.class);
+
+    public HookRegistry() {
+        // 一开始先注册（建立）四种 hook 时机
+        for (HookType type : HookType.values()) {
+            hooks.put(type, new ArrayList<>());
+        }
+    }
+
+    /** 向指定时机追加一个动作，返回自身以便链式注册。 */
+    public HookRegistry register(HookType type, String name, Hook hook) {
+        if (type == null || hook == null) return this;
+        hooks.get(type).add(new Entry(name != null ? name : hook.name(), hook));
+        return this;
+    }
+
+    public HookRegistry register(HookType type, Hook hook) {
+        return register(type, hook.name(), hook);
+    }
+
+    /**
+     * 在指定时机串行触发所有动作。
+     *
+     * @return 聚合结果：命中 BLOCK 则返回该阻断；STOP 命中续跑则返回 CONTINUE_LOOP；否则 PROCEED。
+     */
+    public HookResult fire(HookContext context) {
+        List<Entry> chain = hooks.getOrDefault(context.getType(), Collections.emptyList());
+        if (chain.isEmpty()) {
+            return HookResult.PROCEED; // 空链：不打印、不做任何事
+        }
+
+        // 打印本时机注册的动作：Hook(a、b、c)，走项目 UI 而非裸 System.out
+        StringBuilder names = new StringBuilder();
+        for (Entry entry : chain) {
+            if (names.length() > 0) names.append("、");
+            names.append(entry.name());
+        }
+        if (context.getUi() != null) {
+            context.getUi().displayInfo(context.getType() + " Hook(" + names + ")");
+        }
+
+        for (Entry entry : chain) {
+            HookResult result;
+            try {
+                result = entry.hook().execute(context);
+            } catch (Exception e) {
+                // 单个 hook 崩溃不应中断主循环 —— 降级为放行
+                System.err.println("⚠️ Hook 执行异常 [" + context.getType() + "/" + entry.name()
+                        + "]: " + e.getMessage());
+                continue;
+            }
+            if (result == null) continue;
+
+            if (result.isBlocked() || result.isContinueLoop()) {
+                return result; // 阻断 / 强制续跑 → 提前终止串行链
+            }
+        }
+        return HookResult.PROCEED;
+    }
+
+    /** 某时机已注册的动作数量（便于调试/测试）。 */
+    public int count(HookType type) {
+        return hooks.getOrDefault(type, Collections.emptyList()).size();
+    }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookResult.java
+++ b/src/main/java/com/thoughtcoding/hook/HookResult.java
@@ -1,0 +1,35 @@
+package com.thoughtcoding.hook;
+
+/**
+ * 单个 Hook 动作的执行结果。
+ *
+ * <pre>
+ *   proceed()          → 继续执行后续动作 / 放行本次操作
+ *   block(msg)         → 阻断：串行链路提前终止，本次操作被拒绝（PreToolUse/UserPromptSubmit 生效）
+ *   continueLoop(msg)  → STOP 时机专用：要求循环强制续跑，不退出
+ * </pre>
+ */
+public record HookResult(Decision decision, String message) {
+
+    public enum Decision {
+        /** 放行，继续后续动作。 */
+        PROCEED,
+        /** 阻断当前操作并终止本时机的后续动作。 */
+        BLOCK,
+        /** STOP 时机：阻止退出、强制续跑。 */
+        CONTINUE_LOOP
+    }
+
+    public static final HookResult PROCEED = new HookResult(Decision.PROCEED, null);
+
+    public static HookResult block(String message) {
+        return new HookResult(Decision.BLOCK, message);
+    }
+
+    public static HookResult continueLoop(String message) {
+        return new HookResult(Decision.CONTINUE_LOOP, message);
+    }
+
+    public boolean isBlocked() { return decision == Decision.BLOCK; }
+    public boolean isContinueLoop() { return decision == Decision.CONTINUE_LOOP; }
+}

--- a/src/main/java/com/thoughtcoding/hook/HookResult.java
+++ b/src/main/java/com/thoughtcoding/hook/HookResult.java
@@ -20,7 +20,9 @@ public record HookResult(Decision decision, String message) {
         CONTINUE_LOOP
     }
 
-    public static final HookResult PROCEED = new HookResult(Decision.PROCEED, null);
+    public static HookResult proceed() {
+        return new HookResult(Decision.PROCEED, null);
+    }
 
     public static HookResult block(String message) {
         return new HookResult(Decision.BLOCK, message);

--- a/src/main/java/com/thoughtcoding/hook/HookType.java
+++ b/src/main/java/com/thoughtcoding/hook/HookType.java
@@ -1,0 +1,20 @@
+package com.thoughtcoding.hook;
+
+/**
+ * Hook 触发时机。
+ *
+ * <pre>
+ *   USER_PROMPT_SUBMIT  用户输入提交后、进入 LLM 前  —— 输入验证、注入上下文
+ *   PRE_TOOL_USE        工具执行前                  —— 权限检查、日志记录
+ *   POST_TOOL_USE       工具执行后                  —— 副作用（自动 git add 等）、输出检查
+ *   STOP                循环即将退出时              —— 收尾清理（可强制续跑）
+ * </pre>
+ *
+ * 同一时机内注册的多个动作按注册顺序 <b>串行</b> 执行。
+ */
+public enum HookType {
+    USER_PROMPT_SUBMIT,
+    PRE_TOOL_USE,
+    POST_TOOL_USE,
+    STOP
+}

--- a/src/main/java/com/thoughtcoding/mcp/MCPService.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPService.java
@@ -3,8 +3,7 @@ package com.thoughtcoding.mcp;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.mcp.model.MCPTool;
 import com.thoughtcoding.model.ToolResult;
-import com.thoughtcoding.tools.BaseTool; // 使用你的 BaseTool 基类
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool; // 使用你的 BaseTool 基类
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
+++ b/src/main/java/com/thoughtcoding/mcp/MCPToolManager.java
@@ -1,9 +1,7 @@
 package com.thoughtcoding.mcp;
 
 import com.thoughtcoding.config.MCPConfig;
-import com.thoughtcoding.config.MCPServerConfig;
-import com.thoughtcoding.tools.BaseTool;
-import lombok.extern.slf4j.Slf4j;
+import com.thoughtcoding.tool.BaseTool;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/thoughtcoding/model/SubagentTurn.java
+++ b/src/main/java/com/thoughtcoding/model/SubagentTurn.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * 子代理一轮模型往返的结果载体：模型这一轮产出的文本 + 它请求的工具调用。
+ * 子Agent一轮模型往返的结果载体：模型这一轮产出的文本 + 它请求的工具调用。
  *
  * <p>由 {@code AIService.chatOnceForSubagent} 返回，供 {@code SubAgent} 循环判断：
  * {@link #hasToolCalls()} 为 false → 本轮 {@link #text} 即最终结论；

--- a/src/main/java/com/thoughtcoding/model/SubagentTurn.java
+++ b/src/main/java/com/thoughtcoding/model/SubagentTurn.java
@@ -1,0 +1,34 @@
+package com.thoughtcoding.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 子代理一轮模型往返的结果载体：模型这一轮产出的文本 + 它请求的工具调用。
+ *
+ * <p>由 {@code AIService.chatOnceForSubagent} 返回，供 {@code SubAgent} 循环判断：
+ * {@link #hasToolCalls()} 为 false → 本轮 {@link #text} 即最终结论；
+ * 否则逐个执行 {@link #toolCalls} 后再问下一轮。
+ */
+public class SubagentTurn {
+
+    private final String text;
+    private final List<ToolCallRef> toolCalls;
+
+    public SubagentTurn(String text, List<ToolCallRef> toolCalls) {
+        this.text = text == null ? "" : text;
+        this.toolCalls = toolCalls == null ? Collections.emptyList() : toolCalls;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public List<ToolCallRef> getToolCalls() {
+        return toolCalls;
+    }
+
+    public boolean hasToolCalls() {
+        return toolCalls != null && !toolCalls.isEmpty();
+    }
+}

--- a/src/main/java/com/thoughtcoding/service/AIService.java
+++ b/src/main/java/com/thoughtcoding/service/AIService.java
@@ -24,7 +24,7 @@ public interface AIService {
      * <p>供 {@code SubAgent} 在独立的子代理历史上驱动循环使用。实现须：
      * <ul>
      *   <li>只读 {@code history}（本方法不改写它，由调用方 SubAgent 维护配对）；</li>
-     *   <li>把工具规格里的 {@code task} 过滤掉（禁止子代理递归派生）；</li>
+     *   <li>把工具规格里的 {@code subAgent} 过滤掉（子代理看不到它，无从递归派生）；</li>
      *   <li>自行兜底任何超时/错误，返回一个「无工具调用」的结论文本，<b>永不抛出</b>。</li>
      * </ul>
      *

--- a/src/main/java/com/thoughtcoding/service/AIService.java
+++ b/src/main/java/com/thoughtcoding/service/AIService.java
@@ -19,17 +19,17 @@ public interface AIService {
     List<String> getAvailableModels();
 
     /**
-     * 🔥 子代理专用：一次「隔离」的模型往返，不触碰共享的 messageHandler/toolCallHandler/生成状态。
+     * 🔥 子Agent专用：一次「隔离」的模型往返，不触碰共享的 messageHandler/toolCallHandler/生成状态。
      *
-     * <p>供 {@code SubAgent} 在独立的子代理历史上驱动循环使用。实现须：
+     * <p>供 {@code SubAgent} 在独立的子Agent历史上驱动循环使用。实现须：
      * <ul>
      *   <li>只读 {@code history}（本方法不改写它，由调用方 SubAgent 维护配对）；</li>
-     *   <li>把工具规格里的 {@code subAgent} 过滤掉（子代理看不到它，无从递归派生）；</li>
+     *   <li>把工具规格里的 {@code subAgent} 过滤掉（子Agent看不到它，无从递归派生）；</li>
      *   <li>自行兜底任何超时/错误，返回一个「无工具调用」的结论文本，<b>永不抛出</b>。</li>
      * </ul>
      *
-     * @param systemPrompt 子代理系统提示
-     * @param history      子代理自己的对话历史（只读）
+     * @param systemPrompt 子Agent系统提示
+     * @param history      子Agent自己的对话历史（只读）
      * @param tokenSink    流式 token 回调，用于实时显示（可为 null）
      * @return 本轮结果（文本 + 工具请求）
      */

--- a/src/main/java/com/thoughtcoding/service/AIService.java
+++ b/src/main/java/com/thoughtcoding/service/AIService.java
@@ -1,6 +1,7 @@
 package com.thoughtcoding.service;
 
 import com.thoughtcoding.model.ChatMessage;
+import com.thoughtcoding.model.SubagentTurn;
 import com.thoughtcoding.model.ToolCall;
 
 import java.util.List;
@@ -16,4 +17,24 @@ public interface AIService {
     void setToolCallHandler(Consumer<ToolCall> handler);
     boolean validateModel(String modelName);
     List<String> getAvailableModels();
+
+    /**
+     * 🔥 子代理专用：一次「隔离」的模型往返，不触碰共享的 messageHandler/toolCallHandler/生成状态。
+     *
+     * <p>供 {@code SubAgent} 在独立的子代理历史上驱动循环使用。实现须：
+     * <ul>
+     *   <li>只读 {@code history}（本方法不改写它，由调用方 SubAgent 维护配对）；</li>
+     *   <li>把工具规格里的 {@code task} 过滤掉（禁止子代理递归派生）；</li>
+     *   <li>自行兜底任何超时/错误，返回一个「无工具调用」的结论文本，<b>永不抛出</b>。</li>
+     * </ul>
+     *
+     * @param systemPrompt 子代理系统提示
+     * @param history      子代理自己的对话历史（只读）
+     * @param tokenSink    流式 token 回调，用于实时显示（可为 null）
+     * @return 本轮结果（文本 + 工具请求）
+     */
+    default SubagentTurn chatOnceForSubagent(String systemPrompt, List<ChatMessage> history,
+                                             Consumer<String> tokenSink) {
+        throw new UnsupportedOperationException("chatOnceForSubagent not supported by this AIService");
+    }
 }

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -172,6 +172,32 @@ public class ContextManager {
     }
 
     /**
+     * 🔥 子代理专用系统提示：风格对齐 {@link #buildNativeSystemPrompt}，
+     * 但强调「独立完成这一个任务、不能再派生子代理、只回传最终结论」。
+     * 子代理有自己隔离的对话历史、看不到主对话，故任务细节全在传入的 prompt 里。
+     */
+    public String buildSubagentSystemPrompt() {
+        String cwd = System.getProperty("user.dir");
+        StringBuilder sb = new StringBuilder();
+        sb.append("## 指令\n");
+        sb.append("- 始终用中文回答，解释与代码注释也用中文。\n");
+        sb.append("- 你是被主代理派发的【子代理】，负责独立、完整地完成下面这一个被指派的任务。\n");
+        sb.append("- 你看不到主对话历史，任务所需的全部信息都在给你的任务描述里。\n\n");
+
+        sb.append("## 工作环境\n");
+        sb.append("工作目录: ").append(cwd == null ? "" : cwd).append("\n");
+        sb.append("路径支持：相对路径、绝对路径、~ 用户主目录、.. 上级目录。\n");
+        sb.append("操作系统: ").append(System.getProperty("os.name")).append("\n\n");
+
+        sb.append("## 规则\n");
+        sb.append("1. 需要操作时直接调用系统提供的工具（其名称/说明/参数已由系统注入），不要把工具名写进普通文本，也不要编造工具结果。\n");
+        sb.append("2. 改动已有文件优先用 edit；新建/覆盖用 write；读文件用 read；跑命令或搜索内容用 bash。\n");
+        sb.append("3. 你【不能】再派发子代理，必须自己动手完成这个任务。\n");
+        sb.append("4. 完成后用简洁的中文给出最终结论——这段结论是唯一会回传给主代理的内容，中间过程不会保留，务必把关键结果讲清楚。\n");
+        return sb.toString();
+    }
+
+    /**
      * 🔥 保证发给模型的历史中工具调用/结果配对一致（无论压缩如何裁剪）：
      *  - 丢弃没有对应 assistant 工具调用的孤立 role=tool 结果；
      *  - assistant 消息里剥掉没有对应结果的 toolCalls（非破坏性：修改副本，不动原始历史）。

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -172,17 +172,17 @@ public class ContextManager {
     }
 
     /**
-     * 🔥 子代理专用系统提示：风格对齐 {@link #buildNativeSystemPrompt}，
+     * 🔥 子Agent专用系统提示：风格对齐 {@link #buildNativeSystemPrompt}，
      * 但强调「独立完成这一个任务、只回传最终结论」。
-     * 子代理有自己隔离的对话历史、看不到主对话，故任务细节全在传入的 prompt 里。
-     * （递归无需在提示词里防：subAgent 工具已从子代理可见的工具规格中过滤掉。）
+     * 子Agent有自己隔离的对话历史、看不到主对话，故任务细节全在传入的 prompt 里。
+     * （递归无需在提示词里防：subAgent 工具已从子Agent可见的工具规格中过滤掉。）
      */
     public String buildSubagentSystemPrompt() {
         String cwd = System.getProperty("user.dir");
         StringBuilder sb = new StringBuilder();
         sb.append("## 指令\n");
         sb.append("- 始终用中文回答，解释与代码注释也用中文。\n");
-        sb.append("- 你是被主代理派发的【子代理】，负责独立、完整地完成下面这一个被指派的任务。\n");
+        sb.append("- 你是被主Agent派发的【子Agent】，负责独立、完整地完成下面这一个被指派的任务。\n");
         sb.append("- 你看不到主对话历史，任务所需的全部信息都在给你的任务描述里。\n\n");
 
         sb.append("## 工作环境\n");
@@ -193,7 +193,7 @@ public class ContextManager {
         sb.append("## 规则\n");
         sb.append("1. 需要操作时直接调用系统提供的工具（其名称/说明/参数已由系统注入），不要把工具名写进普通文本，也不要编造工具结果。\n");
         sb.append("2. 改动已有文件优先用 edit；新建/覆盖用 write；读文件用 read；跑命令或搜索内容用 bash。\n");
-        sb.append("3. 完成后用简洁的中文给出最终结论——这段结论是唯一会回传给主代理的内容，中间过程不会保留，务必把关键结果讲清楚。\n");
+        sb.append("3. 完成后用简洁的中文给出最终结论——这段结论是唯一会回传给主Agent的内容，中间过程不会保留，务必把关键结果讲清楚。\n");
         return sb.toString();
     }
 

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -155,7 +155,7 @@ public class ContextManager {
         StringBuilder sb = new StringBuilder();
         sb.append("## 指令\n");
         sb.append("- 始终用中文回答用户的所有问题，解释与代码注释也用中文。\n");
-        sb.append("- 你是一位资深编程助手（类似 Claude Code），可调用工具完成任务。\n\n");
+        sb.append("- 你是一位资深编程助手，可调用工具完成任务。\n\n");
 
         sb.append("## 工作环境\n");
         sb.append("工作目录: ").append(cwd).append("\n");

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -173,8 +173,9 @@ public class ContextManager {
 
     /**
      * 🔥 子代理专用系统提示：风格对齐 {@link #buildNativeSystemPrompt}，
-     * 但强调「独立完成这一个任务、不能再派生子代理、只回传最终结论」。
+     * 但强调「独立完成这一个任务、只回传最终结论」。
      * 子代理有自己隔离的对话历史、看不到主对话，故任务细节全在传入的 prompt 里。
+     * （递归无需在提示词里防：subAgent 工具已从子代理可见的工具规格中过滤掉。）
      */
     public String buildSubagentSystemPrompt() {
         String cwd = System.getProperty("user.dir");
@@ -192,8 +193,7 @@ public class ContextManager {
         sb.append("## 规则\n");
         sb.append("1. 需要操作时直接调用系统提供的工具（其名称/说明/参数已由系统注入），不要把工具名写进普通文本，也不要编造工具结果。\n");
         sb.append("2. 改动已有文件优先用 edit；新建/覆盖用 write；读文件用 read；跑命令或搜索内容用 bash。\n");
-        sb.append("3. 你【不能】再派发子代理，必须自己动手完成这个任务。\n");
-        sb.append("4. 完成后用简洁的中文给出最终结论——这段结论是唯一会回传给主代理的内容，中间过程不会保留，务必把关键结果讲清楚。\n");
+        sb.append("3. 完成后用简洁的中文给出最终结论——这段结论是唯一会回传给主代理的内容，中间过程不会保留，务必把关键结果讲清楚。\n");
         return sb.toString();
     }
 

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -242,7 +242,7 @@ public class LangChainService implements AIService {
         if (toolRegistry != null) {
             List<dev.langchain4j.agent.tool.ToolSpecification> specs = toolRegistry.getToolSpecifications();
             if (specs != null && !specs.isEmpty()) {
-                // 过滤掉 subAgent 自身：子代理看不到 subAgent，无法递归派生（禁止递归第一道）
+                // 过滤掉 subAgent 自身：子代理看不到它，就无从递归派生（防递归的唯一手段）
                 List<dev.langchain4j.agent.tool.ToolSpecification> filtered = new ArrayList<>();
                 for (dev.langchain4j.agent.tool.ToolSpecification s : specs) {
                     if (!"subAgent".equals(s.name())) {

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -171,7 +171,6 @@ public class LangChainService implements AIService {
                             history.add(new ChatMessage("assistant", text));
                         }
                     }
-                    System.out.println();
                 } finally {
                     isGenerating = false;
                     shouldStop = false;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.service;
 
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ChatMessage;
+import com.thoughtcoding.model.SubagentTurn;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolCallRef;
 import com.thoughtcoding.tool.ToolRegistry;
@@ -209,6 +210,95 @@ public class LangChainService implements AIService {
         } catch (Exception e) {
             params.put("input", argumentsJson);
             return params;
+        }
+    }
+
+    /**
+     * 🔥 子代理专用：一次「隔离」的模型往返。
+     *
+     * <p>与 {@link #streamingChat} 的关键区别 —— <b>完全不触碰</b>本实例的共享可变状态
+     * （{@code messageHandler}/{@code toolCallHandler}/{@code isGenerating}/{@code shouldStop}），
+     * 也<b>不改写</b>传入的 history，且从工具规格里过滤掉 {@code task} 以禁止子代理递归。
+     * 用本地 future 阻塞等待，任何超时/错误都兜底为一个「无工具调用」的结论文本，永不抛出。
+     */
+    @Override
+    public SubagentTurn chatOnceForSubagent(String systemPrompt, List<ChatMessage> history,
+                                            java.util.function.Consumer<String> tokenSink) {
+        if (streamingChatModel == null) {
+            return new SubagentTurn("(子代理不可用：模型未初始化)", java.util.Collections.emptyList());
+        }
+
+        // 组装消息：子代理系统提示 + 子代理自己的历史（不走 getContextForAI 压缩，生命周期短）
+        List<dev.langchain4j.data.message.ChatMessage> messages = new ArrayList<>();
+        if (systemPrompt != null && !systemPrompt.isBlank()) {
+            messages.add(dev.langchain4j.data.message.SystemMessage.from(systemPrompt));
+        }
+        if (history != null && !history.isEmpty()) {
+            messages.addAll(convertToLangChainHistory(history));
+        }
+
+        dev.langchain4j.model.chat.request.ChatRequest.Builder reqBuilder =
+                dev.langchain4j.model.chat.request.ChatRequest.builder().messages(messages);
+        if (toolRegistry != null) {
+            List<dev.langchain4j.agent.tool.ToolSpecification> specs = toolRegistry.getToolSpecifications();
+            if (specs != null && !specs.isEmpty()) {
+                // 过滤掉 task 自身：子代理看不到 task，无法递归派生（禁止递归第一道）
+                List<dev.langchain4j.agent.tool.ToolSpecification> filtered = new ArrayList<>();
+                for (dev.langchain4j.agent.tool.ToolSpecification s : specs) {
+                    if (!"task".equals(s.name())) {
+                        filtered.add(s);
+                    }
+                }
+                if (!filtered.isEmpty()) {
+                    reqBuilder.toolSpecifications(filtered);
+                }
+            }
+        }
+        dev.langchain4j.model.chat.request.ChatRequest request = reqBuilder.build();
+
+        final CompletableFuture<SubagentTurn> future = new CompletableFuture<>();
+        streamingChatModel.chat(request, new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String token) {
+                if (tokenSink != null && token != null) {
+                    try {
+                        tokenSink.accept(token);
+                    } catch (Exception ignored) {
+                        // 显示回调异常不影响子代理推进
+                    }
+                }
+            }
+
+            @Override
+            public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse chatResponse) {
+                dev.langchain4j.data.message.AiMessage ai = chatResponse.aiMessage();
+                String text = ai.text();
+                List<ToolCallRef> refs = new ArrayList<>();
+                List<dev.langchain4j.agent.tool.ToolExecutionRequest> requests = ai.toolExecutionRequests();
+                if (requests != null) {
+                    for (dev.langchain4j.agent.tool.ToolExecutionRequest req : requests) {
+                        refs.add(new ToolCallRef(req.id(), req.name(), req.arguments()));
+                    }
+                }
+                future.complete(new SubagentTurn(text, refs));
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        // 异常全包：绝不抛出（ToolDispatcher/SubAgent 依赖这一点保持工具配对不被破坏）
+        try {
+            return future.get(5, TimeUnit.MINUTES);
+        } catch (java.util.concurrent.TimeoutException e) {
+            future.cancel(true);
+            return new SubagentTurn("(子代理调用超时)", java.util.Collections.emptyList());
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new SubagentTurn("(子代理调用失败: " + cause.getMessage() + ")",
+                    java.util.Collections.emptyList());
         }
     }
 

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -4,7 +4,7 @@ import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolCallRef;
-import com.thoughtcoding.tools.ToolRegistry;
+import com.thoughtcoding.tool.ToolRegistry;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -218,7 +218,7 @@ public class LangChainService implements AIService {
      *
      * <p>与 {@link #streamingChat} 的关键区别 —— <b>完全不触碰</b>本实例的共享可变状态
      * （{@code messageHandler}/{@code toolCallHandler}/{@code isGenerating}/{@code shouldStop}），
-     * 也<b>不改写</b>传入的 history，且从工具规格里过滤掉 {@code task} 以禁止子代理递归。
+     * 也<b>不改写</b>传入的 history，且从工具规格里过滤掉 {@code subAgent} 以禁止子代理递归。
      * 用本地 future 阻塞等待，任何超时/错误都兜底为一个「无工具调用」的结论文本，永不抛出。
      */
     @Override
@@ -242,10 +242,10 @@ public class LangChainService implements AIService {
         if (toolRegistry != null) {
             List<dev.langchain4j.agent.tool.ToolSpecification> specs = toolRegistry.getToolSpecifications();
             if (specs != null && !specs.isEmpty()) {
-                // 过滤掉 task 自身：子代理看不到 task，无法递归派生（禁止递归第一道）
+                // 过滤掉 subAgent 自身：子代理看不到 subAgent，无法递归派生（禁止递归第一道）
                 List<dev.langchain4j.agent.tool.ToolSpecification> filtered = new ArrayList<>();
                 for (dev.langchain4j.agent.tool.ToolSpecification s : specs) {
-                    if (!"task".equals(s.name())) {
+                    if (!"subAgent".equals(s.name())) {
                         filtered.add(s);
                     }
                 }

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -214,21 +214,21 @@ public class LangChainService implements AIService {
     }
 
     /**
-     * 🔥 子代理专用：一次「隔离」的模型往返。
+     * 🔥 子Agent专用：一次「隔离」的模型往返。
      *
      * <p>与 {@link #streamingChat} 的关键区别 —— <b>完全不触碰</b>本实例的共享可变状态
      * （{@code messageHandler}/{@code toolCallHandler}/{@code isGenerating}/{@code shouldStop}），
-     * 也<b>不改写</b>传入的 history，且从工具规格里过滤掉 {@code subAgent} 以禁止子代理递归。
+     * 也<b>不改写</b>传入的 history，且从工具规格里过滤掉 {@code subAgent} 以禁止子Agent递归。
      * 用本地 future 阻塞等待，任何超时/错误都兜底为一个「无工具调用」的结论文本，永不抛出。
      */
     @Override
     public SubagentTurn chatOnceForSubagent(String systemPrompt, List<ChatMessage> history,
                                             java.util.function.Consumer<String> tokenSink) {
         if (streamingChatModel == null) {
-            return new SubagentTurn("(子代理不可用：模型未初始化)", java.util.Collections.emptyList());
+            return new SubagentTurn("(子Agent不可用：模型未初始化)", java.util.Collections.emptyList());
         }
 
-        // 组装消息：子代理系统提示 + 子代理自己的历史（不走 getContextForAI 压缩，生命周期短）
+        // 组装消息：子Agent系统提示 + 子Agent自己的历史（不走 getContextForAI 压缩，生命周期短）
         List<dev.langchain4j.data.message.ChatMessage> messages = new ArrayList<>();
         if (systemPrompt != null && !systemPrompt.isBlank()) {
             messages.add(dev.langchain4j.data.message.SystemMessage.from(systemPrompt));
@@ -242,7 +242,7 @@ public class LangChainService implements AIService {
         if (toolRegistry != null) {
             List<dev.langchain4j.agent.tool.ToolSpecification> specs = toolRegistry.getToolSpecifications();
             if (specs != null && !specs.isEmpty()) {
-                // 过滤掉 subAgent 自身：子代理看不到它，就无从递归派生（防递归的唯一手段）
+                // 过滤掉 subAgent 自身：子Agent看不到它，就无从递归派生（防递归的唯一手段）
                 List<dev.langchain4j.agent.tool.ToolSpecification> filtered = new ArrayList<>();
                 for (dev.langchain4j.agent.tool.ToolSpecification s : specs) {
                     if (!"subAgent".equals(s.name())) {
@@ -264,7 +264,7 @@ public class LangChainService implements AIService {
                     try {
                         tokenSink.accept(token);
                     } catch (Exception ignored) {
-                        // 显示回调异常不影响子代理推进
+                        // 显示回调异常不影响子Agent推进
                     }
                 }
             }
@@ -294,10 +294,10 @@ public class LangChainService implements AIService {
             return future.get(5, TimeUnit.MINUTES);
         } catch (java.util.concurrent.TimeoutException e) {
             future.cancel(true);
-            return new SubagentTurn("(子代理调用超时)", java.util.Collections.emptyList());
+            return new SubagentTurn("(子Agent调用超时)", java.util.Collections.emptyList());
         } catch (Exception e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
-            return new SubagentTurn("(子代理调用失败: " + cause.getMessage() + ")",
+            return new SubagentTurn("(子Agent调用失败: " + cause.getMessage() + ")",
                     java.util.Collections.emptyList());
         }
     }

--- a/src/main/java/com/thoughtcoding/tool/BaseTool.java
+++ b/src/main/java/com/thoughtcoding/tool/BaseTool.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.model.ToolResult;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,0 +1,122 @@
+package com.thoughtcoding.tool;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 权限管道 —— AgentLoop 的唯一决策入口。
+ *
+ * <pre>
+ * 调用方式：
+ *   PermissionResult perm = PermissionGate.check(toolName, params);
+ *   if (perm.type() == DENY)  → 直接报错跳过
+ *   if (perm.type() == WARN)  → 弹确认
+ *   // ALLOW → 静默放行
+ * </pre>
+ *
+ * 决策规则：
+ *   read / glob  → 路径越界则 WARN，否则 ALLOW
+ *   write / edit → 固定 WARN
+ *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
+ *   未知工具      → WARN
+ */
+public final class PermissionGate {
+
+    private PermissionGate() {}
+
+    // ═══════════════ Gate 1: 硬拒绝列表 ═══════════════
+
+    private static final List<String> BASH_DENY_PATTERNS = List.of(
+        "rm -rf /", "sudo ", "shutdown", "reboot", "mkfs",
+        "dd if=", "> /dev/sda", "format ", "del /f /s", "rd /s /q"
+    );
+
+    private static PermissionResult checkBashDeny(String command) {
+        if (command == null || command.isBlank()) return null;
+        String lower = command.toLowerCase();
+        for (String pattern : BASH_DENY_PATTERNS) {
+            if (lower.contains(pattern)) {
+                return PermissionResult.deny(
+                    "⛔ 命令被阻止: '" + pattern + "' 在拒绝列表中");
+            }
+        }
+        return null;
+    }
+
+    // ═══════════════ Gate 2: 规则匹配 ═══════════════
+
+    // ── read / glob：路径越界才确认 ──
+    private static PermissionResult checkReadPath(Map<String, Object> params) {
+        String pathStr = paramString(params, "path");
+        if (pathStr == null || pathStr.isBlank()) return PermissionResult.ALLOW;
+
+        try {
+            Path resolved = Sandbox.resolve(pathStr);
+            if (!Sandbox.isWithinWorkspace(resolved)) {
+                return PermissionResult.warn(
+                    "⚠️ 路径在 workspace 之外: " + resolved);
+            }
+        } catch (Exception ignored) {
+            // 解析失败不报 warning
+        }
+        return PermissionResult.ALLOW;
+    }
+
+    // ── bash：先过 Gate 1 拒绝列表，再追加危险模式提示 ──
+    private static PermissionResult checkBash(Map<String, Object> params) {
+        String command = paramString(params, "command");
+
+        // Gate 1: 硬拒绝
+        PermissionResult deny = checkBashDeny(command);
+        if (deny != null) return deny;
+
+        // 固定确认，有危险模式则追加提示
+        String extra = bashWarning(command);
+        return PermissionResult.warn(
+            "⚠️ 将执行 shell 命令" + (extra.isEmpty() ? "" : " —— " + extra));
+    }
+
+    /** 返回危险模式描述，无匹配返回空串。 */
+    private static String bashWarning(String command) {
+        if (command == null || command.isBlank()) return "";
+        String lower = command.toLowerCase();
+
+        if (lower.contains("rm ") || lower.contains("del "))
+            return "包含删除操作";
+        if (lower.contains("> /etc/") || lower.contains("> c:\\windows"))
+            return "写入系统目录";
+        if (lower.contains("chmod 777"))
+            return "修改关键权限";
+        if (lower.contains("git push --force") || lower.contains("git push -f"))
+            return "强制推送";
+        return "";
+    }
+
+    // ═══════════════ 入口 ═══════════════
+
+    /**
+     * 一次性权限决策。
+     *
+     * @return DENY → 拒绝执行；WARN → 弹确认；ALLOW → 静默放行
+     */
+    public static PermissionResult check(String toolName, Map<String, Object> params) {
+        if (toolName == null) return PermissionResult.warn("⚠️ 未知工具");
+
+        return switch (toolName) {
+            case "read", "glob" -> checkReadPath(params);
+            case "write"        -> PermissionResult.warn("⚠️ 将写入文件");
+            case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
+            case "bash"         -> checkBash(params);
+            default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
+        };
+    }
+
+    // ── 工具方法 ──
+
+    private static String paramString(Map<String, Object> params, String key) {
+        if (params == null) return null;
+        Object v = params.get(key);
+        return v == null ? null : v.toString();
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -22,7 +22,7 @@ import java.util.Map;
  *   write / edit → 固定 WARN
  *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
  *   todo_write   → ALLOW（纯内存规划工具，无副作用，静默放行）
- *   task         → ALLOW（子代理内部工具调用各自走权限管道，umbrella 再确认会双重弹框）
+ *   subAgent     → ALLOW（子代理内部工具调用各自走权限管道，umbrella 再确认会双重弹框）
  *   未知工具      → WARN
  */
 public final class PermissionGate {
@@ -114,7 +114,7 @@ public final class PermissionGate {
             case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
             case "bash"         -> checkBash(params);
             case "todo_write"   -> PermissionResult.ALLOW;
-            case "task"         -> PermissionResult.ALLOW;
+            case "subAgent"     -> PermissionResult.ALLOW;
             default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
         };
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -21,6 +21,7 @@ import java.util.Map;
  *   read / glob  → 路径越界则 WARN，否则 ALLOW
  *   write / edit → 固定 WARN
  *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
+ *   todo_write   → ALLOW（纯内存规划工具，无副作用，静默放行）
  *   未知工具      → WARN
  */
 public final class PermissionGate {
@@ -111,6 +112,7 @@ public final class PermissionGate {
             case "write"        -> PermissionResult.warn("⚠️ 将写入文件");
             case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
             case "bash"         -> checkBash(params);
+            case "todo_write"   -> PermissionResult.ALLOW;
             default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
         };
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -22,7 +22,7 @@ import java.util.Map;
  *   write / edit → 固定 WARN
  *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
  *   todo_write   → ALLOW（纯内存规划工具，无副作用，静默放行）
- *   subAgent     → ALLOW（子代理内部工具调用各自走权限管道，umbrella 再确认会双重弹框）
+ *   subAgent     → ALLOW（子Agent内部工具调用各自走权限管道，umbrella 再确认会双重弹框）
  *   未知工具      → WARN
  */
 public final class PermissionGate {

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -22,6 +22,7 @@ import java.util.Map;
  *   write / edit → 固定 WARN
  *   bash         → Gate 1 硬拒绝 DENY，否则固定 WARN（危险模式追加提示）
  *   todo_write   → ALLOW（纯内存规划工具，无副作用，静默放行）
+ *   task         → ALLOW（子代理内部工具调用各自走权限管道，umbrella 再确认会双重弹框）
  *   未知工具      → WARN
  */
 public final class PermissionGate {
@@ -113,6 +114,7 @@ public final class PermissionGate {
             case "edit"         -> PermissionResult.warn("⚠️ 将修改文件");
             case "bash"         -> checkBash(params);
             case "todo_write"   -> PermissionResult.ALLOW;
+            case "task"         -> PermissionResult.ALLOW;
             default             -> PermissionResult.warn("⚠️ 未知工具: " + toolName);
         };
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionGate.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionGate.java
@@ -1,5 +1,7 @@
 package com.thoughtcoding.tool;
 
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +59,9 @@ public final class PermissionGate {
                 return PermissionResult.warn(
                     "⚠️ 路径在 workspace 之外: " + resolved);
             }
-        } catch (Exception ignored) {
-            // 解析失败不报 warning
+        } catch (WorkspaceSecurityException e) {
+            // 路径为空/非法 → 交给工具侧报具体错误，权限不做拦截
+            return PermissionResult.ALLOW;
         }
         return PermissionResult.ALLOW;
     }

--- a/src/main/java/com/thoughtcoding/tool/PermissionHook.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionHook.java
@@ -1,0 +1,70 @@
+package com.thoughtcoding.tool;
+
+import com.thoughtcoding.core.ToolExecutionConfirmation;
+import com.thoughtcoding.hook.Hook;
+import com.thoughtcoding.hook.HookContext;
+import com.thoughtcoding.hook.HookResult;
+import com.thoughtcoding.model.ToolCall;
+import com.thoughtcoding.model.ToolExecution;
+
+/**
+ * 权限检查 Hook —— 将 {@link PermissionGate} 的检查逻辑注册到 PRE_TOOL_USE 时机。
+ *
+ * <p>执行流程：
+ * <ol>
+ *   <li>调用 {@link PermissionGate#check} 获取权限决策</li>
+ *   <li>DENY → {@link HookResult#block}，阻断工具执行</li>
+ *   <li>WARN → 非自动模式下弹出交互式确认框，用户拒绝则阻断</li>
+ *   <li>ALLOW / 自动模式 → 放行</li>
+ * </ol>
+ *
+ * <p>通过 Hook 机制收敛权限检查，使 {@code AgentLoop} 不再内联调用 {@code PermissionGate}，
+ * 统一走 {@code HookRegistry.fire(PRE_TOOL_USE)} 一个入口完成权限决策。
+ */
+public class PermissionHook implements Hook {
+
+    private final ToolExecutionConfirmation confirmation;
+
+    /**
+     * @param confirmation 交互式确认组件（由 AgentLoop 持有），用于 WARN 场景弹框
+     */
+    public PermissionHook(ToolExecutionConfirmation confirmation) {
+        this.confirmation = confirmation;
+    }
+
+    @Override
+    public HookResult execute(HookContext context) {
+        ToolCall call = context.getToolCall();
+        if (call == null) {
+            return HookResult.proceed();
+        }
+
+        PermissionResult perm = PermissionGate.check(call.getToolName(), call.getParameters());
+
+        // ── DENY：硬拒绝，直接阻断 ──
+        if (perm.type() == PermissionResult.Type.DENY) {
+            return HookResult.block(perm.message());
+        }
+
+        // ── WARN：非自动模式弹出确认框 ──
+        if (perm.type() == PermissionResult.Type.WARN && !confirmation.isAutoApproveMode()) {
+            ToolExecution exec = new ToolExecution(
+                    call.getToolName(),
+                    call.getDescription() != null ? call.getDescription() : "执行工具操作",
+                    call.getParameters(),
+                    true);
+            ToolExecutionConfirmation.ActionType action = confirmation.askConfirmationWithOptions(exec);
+            if (action == ToolExecutionConfirmation.ActionType.NO) {
+                return HookResult.block("用户拒绝执行该工具。");
+            }
+        }
+
+        // ── ALLOW / 自动模式放行 ──
+        return HookResult.proceed();
+    }
+
+    @Override
+    public String name() {
+        return "PermissionCheck";
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/PermissionResult.java
+++ b/src/main/java/com/thoughtcoding/tool/PermissionResult.java
@@ -1,0 +1,25 @@
+package com.thoughtcoding.tool;
+
+/**
+ * 权限检查结果。
+ *
+ * <pre>
+ *   deny  → 硬拒绝，不弹确认，直接报错
+ *   warn  → 命中规则，强制弹确认（即使只读工具也不例外）
+ *   allow → 正常走确认流程（该确认的工具会确认，只读工具静默放行）
+ * </pre>
+ */
+public record PermissionResult(Type type, String message) {
+
+    public enum Type { DENY, WARN, ALLOW }
+
+    public static PermissionResult deny(String message) {
+        return new PermissionResult(Type.DENY, message);
+    }
+
+    public static PermissionResult warn(String message) {
+        return new PermissionResult(Type.WARN, message);
+    }
+
+    public static final PermissionResult ALLOW = new PermissionResult(Type.ALLOW, null);
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -1,0 +1,114 @@
+package com.thoughtcoding.tool;
+
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ *
+ * <pre>
+ * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
+ * Path path = Sandbox.safePath(p.toString());
+ * </pre>
+ *
+ * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ */
+public final class Sandbox {
+
+    private static volatile Path workspaceRoot;
+
+    private Sandbox() {
+        // 工具类，禁止实例化
+    }
+
+    // ── 初始化 ──
+
+    /** 由 ThoughtCodingContext 初始化时调用一次。 */
+    public static void init(String workspacePath) {
+        Path raw = Paths.get(workspacePath).toAbsolutePath().normalize();
+        try {
+            workspaceRoot = raw.toRealPath();
+        } catch (Exception e) {
+            workspaceRoot = raw;
+        }
+    }
+
+    private static Path root() {
+        Path r = workspaceRoot;
+        if (r == null) {
+            // 未显式 init 时降级使用当前工作目录
+            r = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+            try {
+                r = r.toRealPath();
+            } catch (Exception ignored) {
+            }
+            workspaceRoot = r;
+        }
+        return r;
+    }
+
+    // ── 核心方法 ──
+
+    /**
+     * 校验并返回安全路径。
+     *
+     * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
+     * @return 已解析的绝对路径
+     * @throws WorkspaceSecurityException 路径在 workspace 之外
+     */
+    public static Path safePath(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            throw new WorkspaceSecurityException("路径不能为空");
+        }
+
+        Path root = root();
+        String expanded = expandUserHome(rawPath.trim());
+        Path target = root.resolve(expanded).normalize();
+
+        try {
+            Path real = target.toRealPath();
+            if (!real.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
+            }
+            return real;
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception fileNotExist) {
+            return validateParent(rawPath, target, root);
+        }
+    }
+
+    /** 文件不存在时，退而校验父目录。 */
+    private static Path validateParent(String rawPath, Path target, Path root) {
+        Path parent = target.getParent();
+        if (parent == null) {
+            throw new WorkspaceSecurityException(
+                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
+        }
+        try {
+            Path realParent = parent.toRealPath();
+            if (!realParent.startsWith(root)) {
+                throw new WorkspaceSecurityException(
+                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
+            }
+        } catch (WorkspaceSecurityException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+        }
+        return target;
+    }
+
+    private static String expandUserHome(String path) {
+        if (path.equals("~")) {
+            return System.getProperty("user.home");
+        }
+        if (path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home") + path.substring(1);
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/Sandbox.java
+++ b/src/main/java/com/thoughtcoding/tool/Sandbox.java
@@ -6,14 +6,21 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * 通用沙箱 —— 校验文件路径必须在 workspace 范围内。
+ * 通用沙箱 —— 路径解析工具。
  *
  * <pre>
- * // 工具内用法（替代原来的 Paths.get(expandUserHome(...)).toAbsolutePath()）：
- * Path path = Sandbox.safePath(p.toString());
+ * // 工具内用法（只解析，不做权限决策）：
+ * Path path = Sandbox.resolve(p.toString());
+ *
+ * // PermissionGate 内用法（组合判断）：
+ * Path resolved = Sandbox.resolve(rawPath);
+ * if (!Sandbox.isWithinWorkspace(resolved)) {
+ *     return PermissionResult.warn("⚠️ 路径在 workspace 之外");
+ * }
  * </pre>
  *
- * 越界时抛出 {@link WorkspaceSecurityException}，由工具的现有 {@code catch (Exception e)} 转为 ToolResult.error。
+ * 权限决策由 PermissionGate 负责，AgentLoop 通过确认框交给用户选择，
+ * 默认 ask 而不是 deny。
  */
 public final class Sandbox {
 
@@ -49,57 +56,43 @@ public final class Sandbox {
         return r;
     }
 
-    // ── 核心方法 ──
+    // ── 路径解析（不做权限决策）──
 
     /**
-     * 校验并返回安全路径。
+     * 解析原始路径为绝对路径（展开 ~、相对于 workspace root 解析、normalize）。
+     * 不做越界检查——权限决策由上层 AgentLoop 负责。
      *
      * @param rawPath 用户输入的原始路径（支持 ~，相对/绝对均可）
      * @return 已解析的绝对路径
-     * @throws WorkspaceSecurityException 路径在 workspace 之外
      */
-    public static Path safePath(String rawPath) {
+    public static Path resolve(String rawPath) {
         if (rawPath == null || rawPath.isBlank()) {
             throw new WorkspaceSecurityException("路径不能为空");
         }
 
         Path root = root();
         String expanded = expandUserHome(rawPath.trim());
-        Path target = root.resolve(expanded).normalize();
-
-        try {
-            Path real = target.toRealPath();
-            if (!real.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → " + real + "（workspace: " + root + "）");
-            }
-            return real;
-        } catch (WorkspaceSecurityException e) {
-            throw e;
-        } catch (Exception fileNotExist) {
-            return validateParent(rawPath, target, root);
-        }
+        return root.resolve(expanded).normalize();
     }
 
-    /** 文件不存在时，退而校验父目录。 */
-    private static Path validateParent(String rawPath, Path target, Path root) {
-        Path parent = target.getParent();
-        if (parent == null) {
-            throw new WorkspaceSecurityException(
-                    "路径越界: '" + rawPath + "' 解析为根目录（workspace: " + root + "）");
-        }
+    /**
+     * 判断给定路径是否在 workspace 范围内。
+     */
+    public static boolean isWithinWorkspace(Path path) {
+        if (path == null) return false;
+        Path root = root();
         try {
-            Path realParent = parent.toRealPath();
-            if (!realParent.startsWith(root)) {
-                throw new WorkspaceSecurityException(
-                        "路径越界: '" + rawPath + "' → 父目录 " + realParent + "（workspace: " + root + "）");
-            }
-        } catch (WorkspaceSecurityException e) {
-            throw e;
+            return path.toRealPath().startsWith(root);
         } catch (Exception e) {
-            throw new WorkspaceSecurityException("无法解析路径: '" + rawPath + "' — " + e.getMessage());
+            // 文件不存在时检查父目录
+            Path parent = path.getParent();
+            if (parent == null) return false;
+            try {
+                return parent.toRealPath().startsWith(root);
+            } catch (Exception ex) {
+                return false;
+            }
         }
-        return target;
     }
 
     private static String expandUserHome(String path) {

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.model.ToolCall;

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
- *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
+ * {@link #dispatch(ToolCall)}。权限检查由 AgentLoop 调用 {@link PermissionGate} 完成，
+ * 工具内部通过 {@link Sandbox#resolve} 只做路径解析，不做权限决策。
  */
 public class ToolDispatcher {
 
@@ -23,7 +23,7 @@ public class ToolDispatcher {
     }
 
     /**
-     * 执行一个工具调用：查表 → 序列化参数 →（沙箱检查）→ 执行。
+     * 执行一个工具调用：查表 → 序列化参数 → 执行。
      */
     public ToolResult dispatch(ToolCall call) {
         long start = System.currentTimeMillis();

--- a/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolDispatcher.java
@@ -10,8 +10,8 @@ import java.util.Map;
  * 工具执行的唯一收口。
  *
  * 所有工具执行 —— 原生 function calling、MCP 工具、以及自动编译/运行 —— 都必须经过
- * {@link #dispatch(ToolCall)}。这样未来的 workspace 沙箱只需在此一处插桩，即可以结构化的
- * (name, args) 看到 100% 的写/执行操作。
+ * {@link #dispatch(ToolCall)}。workspace 沙箱校验已下沉到各工具内部
+ *（{@link Sandbox#safePath}），由 WriteTool/ReadTool/EditTool 各自调用。
  */
 public class ToolDispatcher {
 
@@ -34,11 +34,6 @@ public class ToolDispatcher {
         }
 
         String argsJson = toJson(call.getParameters());
-
-        // 【沙箱插桩点】——下一任务在此插入 workspace 边界检查：
-        //   WriteGuard.check(call.getToolName(), call.getParameters())
-        // 对 write/edit 的 path、bash 的 command 做越界判定，
-        // 越界时直接 return ToolResult.error(...) 不进入 tool.execute。
 
         return tool.execute(argsJson);
     }

--- a/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolRegistry.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.thoughtcoding.config.AppConfig;
 

--- a/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
+++ b/src/main/java/com/thoughtcoding/tool/ToolSpecificationFactory.java
@@ -1,4 +1,4 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;

--- a/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/BashTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.BufferedReader;
@@ -76,21 +77,31 @@ public class BashTool extends BaseTool {
 
             Process process = pb.start();
 
+            // 后台线程消费 stdout，避免主线程因 readLine 阻塞而无法触发超时
             StringBuilder output = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    output.append(line).append("\n");
+            Thread readerThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        output.append(line).append("\n");
+                    }
+                } catch (Exception ignored) {
+                    // 进程被 destroy 后流关闭，忽略
                 }
-            }
+            }, "bash-stdout-reader");
+            readerThread.start();
 
             boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
-                return error("命令超时（>" + timeoutSeconds + "s），已被终止:\n" + output.toString().trim(),
+                readerThread.interrupt();
+                return error("命令超时（>" + timeoutSeconds + "s），已被终止",
                         System.currentTimeMillis() - startTime);
             }
+
+            // 进程已退出，等 reader 线程收完最后几行输出
+            readerThread.join(5000);
 
             int exitCode = process.exitValue();
             String result = output.toString().trim();

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -84,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -56,7 +58,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -83,6 +85,8 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/EditTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -58,7 +57,7 @@ public class EditTool extends BaseTool {
             boolean replaceAll = Boolean.TRUE.equals(params.get("replace_all"))
                     || "true".equalsIgnoreCase(String.valueOf(params.get("replace_all")));
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (!Files.exists(path) || Files.isDirectory(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
             }
@@ -85,8 +84,6 @@ public class EditTool extends BaseTool {
             return success("已在 " + path + " 替换 " + (replaceAll ? count : 1) + " 处",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("编辑失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -1,8 +1,9 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
@@ -13,7 +14,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
+
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class GlobTool extends BaseTool {
             Object pathObj = params.get("path");
             String basePathStr = (pathObj == null || pathObj.toString().trim().isEmpty())
                     ? "." : pathObj.toString();
-            Path base = Paths.get(expandUserHome(basePathStr)).toAbsolutePath().normalize();
+            Path base = Sandbox.resolve(basePathStr);
 
             if (!Files.exists(base) || !Files.isDirectory(base)) {
                 return error("目录不存在: " + basePathStr, System.currentTimeMillis() - startTime);

--- a/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/GlobTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -130,6 +131,8 @@ public class GlobTool extends BaseTool {
             }
             return success(sb.toString().trim(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("查找失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +55,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -91,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -55,7 +54,7 @@ public class ReadTool extends BaseTool {
             if (p == null) {
                 return error("read 需要 'path' 字段", System.currentTimeMillis() - startTime);
             }
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
 
             if (!Files.exists(path)) {
                 return error("文件不存在: " + p, System.currentTimeMillis() - startTime);
@@ -93,8 +92,6 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/ReadTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -92,6 +93,8 @@ public class ReadTool extends BaseTool {
             }
             return success(sb.toString(), System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("读取失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
@@ -35,7 +35,7 @@ public class SubAgentTool extends BaseTool {
     private final ThoughtCodingContext context;
 
     public SubAgentTool(ThoughtCodingContext context) {
-        super("task",
+        super("subAgent",
                 "把一个复杂、可独立完成的多步子任务派发给子代理处理，让主对话保持干净。\n"
                 + "何时使用：任务较大且可独立完成（如“在某模块实现并自测一个功能”“调研代码库某问题并给出结论”），"
                 + "其大量中间步骤（读文件、跑命令、试错）不需要留在主对话里时。简单/单步任务直接自己做，无需使用。\n"

--- a/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
@@ -1,0 +1,102 @@
+package com.thoughtcoding.tool.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtcoding.core.SubAgent;
+import com.thoughtcoding.core.ThoughtCodingContext;
+import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+
+import java.util.Map;
+
+/**
+ * task 工具：把一个复杂、可独立完成的多步子任务派发给【子代理】处理。
+ *
+ * <p>子代理在全新、隔离的对话历史里跑自己的 agentic 循环（可用除 task 外的全部工具），
+ * 跑完只把<b>最终结论</b>回传给主代理，所有中间过程（读文件、跑命令、试错）都不进主上下文。
+ * 因此它增加的是「把大任务外包出去、保持主上下文干净」的能力，而非新的执行能力。
+ *
+ * <p><b>关键约束</b>：
+ * <ul>
+ *   <li>子代理看不到主对话历史 —— {@code prompt} 必须自包含，把背景/目标/约束/验收标准讲清楚；</li>
+ *   <li>子代理<b>不能</b>再派发子代理（本工具用 {@link #RUNNING} ThreadLocal 结构性阻断嵌套，
+ *       与 {@link SubAgent} 循环里的按名拦截构成双保险）；</li>
+ *   <li>只返回最终结论，无法拿回中间步骤；</li>
+ *   <li>子代理内部的写/执行类工具照样走权限确认（安全不打折）。</li>
+ * </ul>
+ */
+public class SubAgentTool extends BaseTool {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 结构性防递归：标记当前线程是否已在子代理内运行。 */
+    private static final ThreadLocal<Boolean> RUNNING = ThreadLocal.withInitial(() -> false);
+
+    private final ThoughtCodingContext context;
+
+    public SubAgentTool(ThoughtCodingContext context) {
+        super("task",
+                "把一个复杂、可独立完成的多步子任务派发给子代理处理，让主对话保持干净。\n"
+                + "何时使用：任务较大且可独立完成（如“在某模块实现并自测一个功能”“调研代码库某问题并给出结论”），"
+                + "其大量中间步骤（读文件、跑命令、试错）不需要留在主对话里时。简单/单步任务直接自己做，无需使用。\n"
+                + "注意：子代理【看不到】当前对话历史，prompt 必须自包含（写清背景、目标、约束、期望的结论形式）；"
+                + "子代理只会回传【最终结论】，中间过程不保留；子代理【不能】再派发子代理。\n"
+                + "参数：description（简短任务标签，用于展示）、prompt（交给子代理的详细任务指令）。");
+        this.context = context;
+    }
+
+    @Override
+    public JsonObjectSchema inputSchema() {
+        return JsonObjectSchema.builder()
+                .addStringProperty("description", "子代理任务的简短标签（3-8 字，用于终端展示）")
+                .addStringProperty("prompt",
+                        "交给子代理的详细任务指令。必须自包含——子代理看不到主对话，"
+                        + "请把背景、目标、约束、期望的结论形式都写清楚。")
+                .required("description", "prompt")
+                .additionalProperties(false)
+                .build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ToolResult execute(String input) {
+        long startTime = System.currentTimeMillis();
+        try {
+            // 结构性防递归：子代理内部即使幻觉调用 task，也在这里被挡下
+            if (Boolean.TRUE.equals(RUNNING.get())) {
+                return error("不支持嵌套子代理：task 不能在子代理内部再次调用。",
+                        System.currentTimeMillis() - startTime);
+            }
+
+            Map<String, Object> params = MAPPER.readValue(input, Map.class);
+
+            Object promptObj = params.get("prompt");
+            String prompt = promptObj == null ? "" : promptObj.toString().trim();
+            if (prompt.isEmpty()) {
+                return error("task 需要 'prompt' 字段（交给子代理的详细任务指令）",
+                        System.currentTimeMillis() - startTime);
+            }
+
+            Object descObj = params.get("description");
+            String description = descObj == null ? "" : descObj.toString().trim();
+            if (description.isEmpty()) {
+                return error("task 需要 'description' 字段（简短任务标签）",
+                        System.currentTimeMillis() - startTime);
+            }
+
+            RUNNING.set(true);
+            try {
+                String conclusion = new SubAgent(context).run(prompt, description);
+                return success(
+                        conclusion == null || conclusion.isBlank()
+                                ? "子代理已结束，但未产出文本结论。" : conclusion,
+                        System.currentTimeMillis() - startTime);
+            } finally {
+                RUNNING.set(false);
+            }
+        } catch (Exception e) {
+            // 兜底：ToolDispatcher.dispatch 不做 try/catch，异常绝不能从这里逃逸破坏主轮次的工具配对
+            return error("task 执行失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
+        }
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
@@ -10,27 +10,24 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import java.util.Map;
 
 /**
- * task 工具：把一个复杂、可独立完成的多步子任务派发给【子代理】处理。
+ * subAgent 工具：把一个复杂、可独立完成的多步子任务派发给【子代理】处理。
  *
- * <p>子代理在全新、隔离的对话历史里跑自己的 agentic 循环（可用除 task 外的全部工具），
+ * <p>子代理在全新、隔离的对话历史里跑自己的 agentic 循环（可用除 subAgent 外的全部工具），
  * 跑完只把<b>最终结论</b>回传给主代理，所有中间过程（读文件、跑命令、试错）都不进主上下文。
  * 因此它增加的是「把大任务外包出去、保持主上下文干净」的能力，而非新的执行能力。
  *
  * <p><b>关键约束</b>：
  * <ul>
  *   <li>子代理看不到主对话历史 —— {@code prompt} 必须自包含，把背景/目标/约束/验收标准讲清楚；</li>
- *   <li>子代理<b>不能</b>再派发子代理（本工具用 {@link #RUNNING} ThreadLocal 结构性阻断嵌套，
- *       与 {@link SubAgent} 循环里的按名拦截构成双保险）；</li>
  *   <li>只返回最终结论，无法拿回中间步骤；</li>
- *   <li>子代理内部的写/执行类工具照样走权限确认（安全不打折）。</li>
+ *   <li>子代理内部的写/执行类工具照样走权限确认（安全不打折）；</li>
+ *   <li>不会递归：{@code chatOnceForSubagent} 已把 subAgent 自身从子代理可见的工具规格中过滤掉，
+ *       模型根本拿不到这个工具，也就无从再派发子代理。</li>
  * </ul>
  */
 public class SubAgentTool extends BaseTool {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    /** 结构性防递归：标记当前线程是否已在子代理内运行。 */
-    private static final ThreadLocal<Boolean> RUNNING = ThreadLocal.withInitial(() -> false);
 
     private final ThoughtCodingContext context;
 
@@ -40,7 +37,7 @@ public class SubAgentTool extends BaseTool {
                 + "何时使用：任务较大且可独立完成（如“在某模块实现并自测一个功能”“调研代码库某问题并给出结论”），"
                 + "其大量中间步骤（读文件、跑命令、试错）不需要留在主对话里时。简单/单步任务直接自己做，无需使用。\n"
                 + "注意：子代理【看不到】当前对话历史，prompt 必须自包含（写清背景、目标、约束、期望的结论形式）；"
-                + "子代理只会回传【最终结论】，中间过程不保留；子代理【不能】再派发子代理。\n"
+                + "子代理只会回传【最终结论】，中间过程不保留。\n"
                 + "参数：description（简短任务标签，用于展示）、prompt（交给子代理的详细任务指令）。");
         this.context = context;
     }
@@ -62,41 +59,30 @@ public class SubAgentTool extends BaseTool {
     public ToolResult execute(String input) {
         long startTime = System.currentTimeMillis();
         try {
-            // 结构性防递归：子代理内部即使幻觉调用 task，也在这里被挡下
-            if (Boolean.TRUE.equals(RUNNING.get())) {
-                return error("不支持嵌套子代理：task 不能在子代理内部再次调用。",
-                        System.currentTimeMillis() - startTime);
-            }
-
             Map<String, Object> params = MAPPER.readValue(input, Map.class);
 
             Object promptObj = params.get("prompt");
             String prompt = promptObj == null ? "" : promptObj.toString().trim();
             if (prompt.isEmpty()) {
-                return error("task 需要 'prompt' 字段（交给子代理的详细任务指令）",
+                return error("subAgent 需要 'prompt' 字段（交给子代理的详细任务指令）",
                         System.currentTimeMillis() - startTime);
             }
 
             Object descObj = params.get("description");
             String description = descObj == null ? "" : descObj.toString().trim();
             if (description.isEmpty()) {
-                return error("task 需要 'description' 字段（简短任务标签）",
+                return error("subAgent 需要 'description' 字段（简短任务标签）",
                         System.currentTimeMillis() - startTime);
             }
 
-            RUNNING.set(true);
-            try {
-                String conclusion = new SubAgent(context).run(prompt, description);
-                return success(
-                        conclusion == null || conclusion.isBlank()
-                                ? "子代理已结束，但未产出文本结论。" : conclusion,
-                        System.currentTimeMillis() - startTime);
-            } finally {
-                RUNNING.set(false);
-            }
+            String conclusion = new SubAgent(context).run(prompt, description);
+            return success(
+                    conclusion == null || conclusion.isBlank()
+                            ? "子代理已结束，但未产出文本结论。" : conclusion,
+                    System.currentTimeMillis() - startTime);
         } catch (Exception e) {
             // 兜底：ToolDispatcher.dispatch 不做 try/catch，异常绝不能从这里逃逸破坏主轮次的工具配对
-            return error("task 执行失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
+            return error("subAgent 执行失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         }
     }
 }

--- a/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/SubAgentTool.java
@@ -10,19 +10,19 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import java.util.Map;
 
 /**
- * subAgent 工具：把一个复杂、可独立完成的多步子任务派发给【子代理】处理。
+ * subAgent 工具：把一个复杂、可独立完成的多步子任务派发给【子Agent】处理。
  *
- * <p>子代理在全新、隔离的对话历史里跑自己的 agentic 循环（可用除 subAgent 外的全部工具），
- * 跑完只把<b>最终结论</b>回传给主代理，所有中间过程（读文件、跑命令、试错）都不进主上下文。
+ * <p>子Agent在全新、隔离的对话历史里跑自己的 agentic 循环（可用除 subAgent 外的全部工具），
+ * 跑完只把<b>最终结论</b>回传给主Agent，所有中间过程（读文件、跑命令、试错）都不进主上下文。
  * 因此它增加的是「把大任务外包出去、保持主上下文干净」的能力，而非新的执行能力。
  *
  * <p><b>关键约束</b>：
  * <ul>
- *   <li>子代理看不到主对话历史 —— {@code prompt} 必须自包含，把背景/目标/约束/验收标准讲清楚；</li>
+ *   <li>子Agent看不到主对话历史 —— {@code prompt} 必须自包含，把背景/目标/约束/验收标准讲清楚；</li>
  *   <li>只返回最终结论，无法拿回中间步骤；</li>
- *   <li>子代理内部的写/执行类工具照样走权限确认（安全不打折）；</li>
- *   <li>不会递归：{@code chatOnceForSubagent} 已把 subAgent 自身从子代理可见的工具规格中过滤掉，
- *       模型根本拿不到这个工具，也就无从再派发子代理。</li>
+ *   <li>子Agent内部的写/执行类工具照样走权限确认（安全不打折）；</li>
+ *   <li>不会递归：{@code chatOnceForSubagent} 已把 subAgent 自身从子Agent可见的工具规格中过滤掉，
+ *       模型根本拿不到这个工具，也就无从再派发子Agent。</li>
  * </ul>
  */
 public class SubAgentTool extends BaseTool {
@@ -33,21 +33,21 @@ public class SubAgentTool extends BaseTool {
 
     public SubAgentTool(ThoughtCodingContext context) {
         super("subAgent",
-                "把一个复杂、可独立完成的多步子任务派发给子代理处理，让主对话保持干净。\n"
+                "把一个复杂、可独立完成的多步子任务派发给子Agent处理，让主对话保持干净。\n"
                 + "何时使用：任务较大且可独立完成（如“在某模块实现并自测一个功能”“调研代码库某问题并给出结论”），"
                 + "其大量中间步骤（读文件、跑命令、试错）不需要留在主对话里时。简单/单步任务直接自己做，无需使用。\n"
-                + "注意：子代理【看不到】当前对话历史，prompt 必须自包含（写清背景、目标、约束、期望的结论形式）；"
-                + "子代理只会回传【最终结论】，中间过程不保留。\n"
-                + "参数：description（简短任务标签，用于展示）、prompt（交给子代理的详细任务指令）。");
+                + "注意：子Agent【看不到】当前对话历史，prompt 必须自包含（写清背景、目标、约束、期望的结论形式）；"
+                + "子Agent只会回传【最终结论】，中间过程不保留。\n"
+                + "参数：description（简短任务标签，用于展示）、prompt（交给子Agent的详细任务指令）。");
         this.context = context;
     }
 
     @Override
     public JsonObjectSchema inputSchema() {
         return JsonObjectSchema.builder()
-                .addStringProperty("description", "子代理任务的简短标签（3-8 字，用于终端展示）")
+                .addStringProperty("description", "子Agent任务的简短标签（3-8 字，用于终端展示）")
                 .addStringProperty("prompt",
-                        "交给子代理的详细任务指令。必须自包含——子代理看不到主对话，"
+                        "交给子Agent的详细任务指令。必须自包含——子Agent看不到主对话，"
                         + "请把背景、目标、约束、期望的结论形式都写清楚。")
                 .required("description", "prompt")
                 .additionalProperties(false)
@@ -64,7 +64,7 @@ public class SubAgentTool extends BaseTool {
             Object promptObj = params.get("prompt");
             String prompt = promptObj == null ? "" : promptObj.toString().trim();
             if (prompt.isEmpty()) {
-                return error("subAgent 需要 'prompt' 字段（交给子代理的详细任务指令）",
+                return error("subAgent 需要 'prompt' 字段（交给子Agent的详细任务指令）",
                         System.currentTimeMillis() - startTime);
             }
 
@@ -78,7 +78,7 @@ public class SubAgentTool extends BaseTool {
             String conclusion = new SubAgent(context).run(prompt, description);
             return success(
                     conclusion == null || conclusion.isBlank()
-                            ? "子代理已结束，但未产出文本结论。" : conclusion,
+                            ? "子Agent已结束，但未产出文本结论。" : conclusion,
                     System.currentTimeMillis() - startTime);
         } catch (Exception e) {
             // 兜底：ToolDispatcher.dispatch 不做 try/catch，异常绝不能从这里逃逸破坏主轮次的工具配对

--- a/src/main/java/com/thoughtcoding/tool/tools/TodoWriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/TodoWriteTool.java
@@ -1,0 +1,152 @@
+package com.thoughtcoding.tool.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * todo_write 工具：创建并维护一个结构化的待办清单，用于规划、跟踪多步骤任务的进度。
+ *
+ * <p>它<b>不增加任何执行能力</b>——不读写文件、不跑命令，只是把模型给出的完整任务清单
+ * 存在会话内并渲染出来。它增加的是<b>规划能力</b>：让模型显式拆解大任务、跟踪进度、
+ * 上下文变长后也不会忘记待办。
+ *
+ * <p>状态保存在实例字段里：本工具在 {@code ToolRegistry} 中是单例，同一会话内多次调用
+ * 复用同一实例，因此 {@link #todos} 跨调用保留（等价于教学示例里的全局 {@code CURRENT_TODOS}）。
+ * {@code AgentLoop} 单线程顺序执行工具，无并发问题。模型每次都传【完整】列表，整体替换。
+ */
+public class TodoWriteTool extends BaseTool {
+
+    /** 合法状态值。 */
+    private static final List<String> STATUSES = List.of("pending", "in_progress", "completed");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 会话内的当前任务清单（跨调用保留）。 */
+    private final List<Todo> todos = new ArrayList<>();
+
+    /** 单个待办项：任务描述 + 状态。 */
+    private record Todo(String content, String status) {
+    }
+
+    public TodoWriteTool() {
+        super("todo_write",
+                "创建并维护一个结构化的待办清单，用于规划和跟踪多步骤任务的进度。\n"
+                + "何时使用：任务需要 3 个及以上步骤、较复杂/非平凡；用户一次给出多项任务；或你刚开始一项较大的任务时。\n"
+                + "用法：传入【完整】的 todos 列表（每次调用都要传全量，包含已完成项，而非只传增量）；"
+                + "每项含 content（任务描述，祈使句）与 status（pending/in_progress/completed）。\n"
+                + "规则：同一时刻最多只应有一个任务处于 in_progress；完成一项后立即标记为 completed，并把下一项置为 in_progress。\n"
+                + "注意：本工具只做规划、不执行任何实际操作，也不读写文件。简单的单步任务或纯咨询类问题无需使用。");
+    }
+
+    @Override
+    public JsonObjectSchema inputSchema() {
+        JsonObjectSchema item = JsonObjectSchema.builder()
+                .addStringProperty("content", "任务的简短描述（祈使句，如“实现登录接口”）")
+                .addEnumProperty("status", STATUSES, "任务状态：pending（待办）/ in_progress（进行中）/ completed（已完成）")
+                .required("content", "status")
+                .additionalProperties(false)
+                .build();
+
+        JsonArraySchema todosArray = JsonArraySchema.builder()
+                .description("完整的任务清单。每次调用都要传【全量】列表（含已完成项），而不是增量。")
+                .items(item)
+                .build();
+
+        return JsonObjectSchema.builder()
+                .addProperty("todos", todosArray)
+                .required("todos")
+                .additionalProperties(false)
+                .build();
+    }
+
+    /** 纯规划工具，无副作用，静默放行（权限见 PermissionGate 的 todo_write 分支）。 */
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ToolResult execute(String input) {
+        long startTime = System.currentTimeMillis();
+        try {
+            Map<String, Object> params = MAPPER.readValue(input, Map.class);
+
+            Object todosObj = params.get("todos");
+            if (!(todosObj instanceof List)) {
+                return error("todo_write 需要 'todos' 数组（完整任务清单）", System.currentTimeMillis() - startTime);
+            }
+
+            List<Object> raw = (List<Object>) todosObj;
+
+            // 空列表 → 清空清单
+            if (raw.isEmpty()) {
+                todos.clear();
+                return success("任务清单已清空。", System.currentTimeMillis() - startTime);
+            }
+
+            List<Todo> parsed = new ArrayList<>();
+            for (Object o : raw) {
+                if (!(o instanceof Map)) {
+                    continue;
+                }
+                Map<String, Object> item = (Map<String, Object>) o;
+
+                Object contentObj = item.get("content");
+                String content = contentObj == null ? "" : contentObj.toString().trim();
+                if (content.isEmpty()) {
+                    continue; // 跳过无 content 的无效项
+                }
+
+                Object statusObj = item.get("status");
+                String status = statusObj == null ? "" : statusObj.toString().trim().toLowerCase(Locale.ROOT);
+                if (!STATUSES.contains(status)) {
+                    status = "pending"; // 非法/缺失状态回退为 pending
+                }
+
+                parsed.add(new Todo(content, status));
+            }
+
+            if (parsed.isEmpty()) {
+                return error("没有有效的任务项（每项需包含非空 content）", System.currentTimeMillis() - startTime);
+            }
+
+            // 整体替换会话内清单
+            todos.clear();
+            todos.addAll(parsed);
+
+            return success(render(), System.currentTimeMillis() - startTime);
+
+        } catch (Exception e) {
+            return error("todo_write 参数解析失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
+        }
+    }
+
+    /** 把当前清单渲染为带图标的进度视图（既用于终端显示，也回喂给模型确认状态）。 */
+    private String render() {
+        long done = todos.stream().filter(t -> "completed".equals(t.status())).count();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("TodoList (").append(done).append('/').append(todos.size()).append(")\n");
+        for (Todo t : todos) {
+            sb.append("  ").append(icon(t.status())).append(' ').append(t.content()).append('\n');
+        }
+        return sb.toString().trim();
+    }
+
+    private static String icon(String status) {
+        return switch (status) {
+            case "completed" -> "✓";
+            case "in_progress" -> "▸";
+            default -> "○";
+        };
+    }
+}

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
-import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
@@ -50,7 +49,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Sandbox.safePath(p.toString());
+            Path path = Sandbox.resolve(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -59,8 +58,6 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
-        } catch (WorkspaceSecurityException e) {
-            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -1,14 +1,16 @@
-package com.thoughtcoding.tools;
+package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.model.ToolResult;
+import com.thoughtcoding.tool.BaseTool;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
+import com.thoughtcoding.tool.Sandbox;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -48,7 +50,7 @@ public class WriteTool extends BaseTool {
             }
             String content = c.toString();
 
-            Path path = Paths.get(expandUserHome(p.toString())).toAbsolutePath();
+            Path path = Sandbox.safePath(p.toString());
             if (path.getParent() != null) {
                 Files.createDirectories(path.getParent());
             }
@@ -57,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {

--- a/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
+++ b/src/main/java/com/thoughtcoding/tool/tools/WriteTool.java
@@ -2,6 +2,7 @@ package com.thoughtcoding.tool.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.exception.WorkspaceSecurityException;
 import com.thoughtcoding.model.ToolResult;
 import com.thoughtcoding.tool.BaseTool;
 import com.thoughtcoding.tool.Sandbox;
@@ -58,6 +59,8 @@ public class WriteTool extends BaseTool {
             return success("已写入: " + path + " (" + content.length() + " 字符)",
                     System.currentTimeMillis() - startTime);
 
+        } catch (WorkspaceSecurityException e) {
+            return error(e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (IOException e) {
             return error("写入失败: " + e.getMessage(), System.currentTimeMillis() - startTime);
         } catch (Exception e) {


### PR DESCRIPTION

  实现 Subagent 子代理能力并收敛命名

  变更类型

  - [x] 新功能 (feature)
  - [x] 重构 (refactor)

  变更摘要

  10 files changed, +480 / -5。核心变更为：新增 subagent 工具，让主代理可把复杂、可独立完成的子任务派发给一个【全新、隔
  离】的对话历史里运行的子循环，跑完只回传最终结论、保持主上下文干净；配套新增隔离的模型往返
  chatOnceForSubagent、子代理专用系统提示、权限放行与防递归措施，并将工具名
  task→subagent、术语「子代理→子agent」统一收敛。

  一、Subagent 核心循环与工具


  问题：主代理处理大任务时，大量中间步骤（读文件、跑命令、试错）会污染主对话上下文，且无法把可独立完成的子任务外包出去。

    改动：
  - 新增 core/Subagent.java（196 行）：在全新隔离 history 中跑独立 agentic
  循环，只回传最终结论；自带独立权限栈（HookRegistry + PermissionHook），内部写/执行类工具仍走 PRE_TOOL_USE
  管道；每个工具调用严格配对恰好一个 tool 结果（保证下一轮不 400）；达到最大轮次或异常均兜底返回结论文本，绝不逃逸
  - 新增 tool/tools/SubagentTool.java（88 行）：subagent 工具，接收自包含的 prompt + description；用
  ThreadLocal<Boolean> RUNNING 结构性阻断嵌套调用；背景提示必须自包含（子代理看不到主对话）
  - 新增 model/SubagentTurn.java（34 行）：一轮隔离模型往返的结果载体（文本 + 工具调用引用），hasToolCalls() 为 false
  即最终结论
  - core/ThoughtCodingContext.java（+9）：build 之后注册 SubagentTool(context)（需已构建好的 context
  引用派生隔离子循环）
  - core/AgentLoop.java（+11）：displayNativeToolResult 对 subagent 工具跳过重复
  dump，仅打印「子代理已返回结论」，避免刷屏（结论仍写回 history 回喂模型）
  - tool/PermissionGate.java（+2）：case "subagent" -> ALLOW（内部工具各自走权限管道，umbrella 再确认会双重弹框）

  二、隔离模型往返与专用系统提示

问题：子代理若复用主循环共享的流式回调/生成状态，会与主循环争抢，且共享可变状态在嵌套调用下不安全。

    改动：
  - service/AIService.java（+21）：新增 chatOnceForSubagent() 接口方法，契约明确——只读
  history、不改写它、从工具规格过滤掉 subagent
  自身（禁止递归第一道）、任何超时/错误都兜底为「无工具调用」结论文本、永不抛出（默认实现抛
  UnsupportedOperationException）
  - service/LangChainService.java（+90）：实现 chatOnceForSubagent，用本地 CompletableFuture 阻塞等待，完全不触碰
  messageHandler/toolCallHandler/isGenerating/shouldStop 等共享状态；从工具规格过滤 subagent；超时（5
  分钟）/异常均兜底返回结论文本
  - service/ContextManager.java（+28）：新增
  buildSubagentSystemPrompt()，风格对齐主系统提示，强调「独立完成任务、只回传最终结论」

  三、防递归与冗余防御清理

    问题：Subagent 循环内原本按名拦截 subagent
  调用做递归硬闸，但该工具已从子代理可见的工具规格中过滤掉，模型根本看不到它，按名拦截是冗余代码。

    改动：
  - core/Subagent.java（−7）：删除循环内的 if ("subagent".equals(name))
  拦截分支；防递归统一收敛为「工具规格过滤」（唯一手段），SubagentTool 的 ThreadLocal RUNNING 仍保留作为结构性双保险
  - service/AIService.java / service/ContextManager.java / core/Subagent.java
  注释同步改写：递归无需在提示词/循环里防，由规格过滤保证
  - ContextManager.buildSubagentSystemPrompt 删除规则「3. 你【不能】再派发子代理」（该约束改由工具不可见性保证），原规则
  4 顺提为 3

  四、轮次调整与命名/术语收敛

    问题：工具名 task 与术语「子代理」在不同提交里逐步与 subagent / 子agent
  命名体系统一，且子代理工具调用轮次上限初值（10）偏小，复杂任务易提前截断。

    改动：
  - core/Subagent.java：子代理工具调用最大轮次由 10 调整为 30（去掉从 AppConfig.AIConfig.getMaxToolIterations()
  取值，改为固定 30）
  - 工具名 task → subagent：覆盖 SubagentTool 构造、PermissionGate 分支、LangChainService 规格过滤、Subagent
  引用、displayNativeToolResult 判断、AIService/ContextManager 注释
  - 术语「子代理」→「子agent」：统一于各文件注释与终端/系统提示文案（如「子agent已返回结论」「子agent不可用」）
  - core/ToolExecutionConfirmation.java（−2 emoji）：移除自动批准/交互模式切换提示中的 🤖/👤 emoji，仅保留纯文本
  - service/ContextManager.java：主系统提示精简一句冗余措辞（「类似 Claude Code」去除）