### PR TITLE
新增重复工具调用防护Hook，兜底Agent循环同入参重复调用

### DIFF
--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -1,6 +1,7 @@
 package com.thoughtcoding.core;
 
 import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.hook.DuplicateToolCallGuard;
 import com.thoughtcoding.hook.HookContext;
 import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.hook.HookResult;
@@ -35,6 +36,7 @@ public class AgentLoop {
     private final ToolExecutionConfirmation confirmation;  // 交互式确认组件
     private final ToolExecutionPipeline toolPipeline;
     private final HookRegistry hookRegistry;               // 基于注册表的 Hook 系统
+    private final DuplicateToolCallGuard duplicateCallGuard;  // 死循环兜底：拦截同入参重复工具调用
 
     // 缓存本轮模型请求的工具调用（原生路径一轮可能有多个）
     private final List<ToolCall> pendingToolCalls = new ArrayList<>();
@@ -57,6 +59,11 @@ public class AgentLoop {
         // 权限检查必须位于业务扩展之前，且确认组件属于当前 Agent 实例。
         this.hookRegistry.registerFirst(com.thoughtcoding.hook.HookType.PRE_TOOL_USE,
                 new PermissionHook(this.confirmation));
+        // 死循环兜底：同一消费方连续两次完全相同的工具调用，第二次直接拦截回喂报错。
+        // registerFirst 插到最前，先于 PermissionHook，避免对注定被拦的调用重复弹确认框。
+        this.duplicateCallGuard = new DuplicateToolCallGuard();
+        this.hookRegistry.registerFirst(com.thoughtcoding.hook.HookType.PRE_TOOL_USE,
+                this.duplicateCallGuard);
         this.toolPipeline = new ToolExecutionPipeline(
                 context, this.hookRegistry, context.getToolRegistry());
 
@@ -87,6 +94,7 @@ public class AgentLoop {
 
         try {
             pendingToolCalls.clear();
+            duplicateCallGuard.reset();   // 每轮用户对话重置重复调用记忆，跨轮的相同首调不误拦
 
             // ── Hook: UserPromptSubmit（进入 LLM 前）—— BLOCK 则跳过本轮 ──
             HookContext promptContext = HookContext.forUserPrompt(context, history, input);

--- a/src/main/java/com/thoughtcoding/core/SubAgent.java
+++ b/src/main/java/com/thoughtcoding/core/SubAgent.java
@@ -1,6 +1,7 @@
 package com.thoughtcoding.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtcoding.hook.DuplicateToolCallGuard;
 import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.hook.HookType;
 import com.thoughtcoding.model.ChatMessage;
@@ -64,6 +65,8 @@ public class SubAgent {
                         context::getConsoleInputRouter);
         HookRegistry hookRegistry = context.getHookRegistry().copy();
         hookRegistry.registerFirst(HookType.PRE_TOOL_USE, new PermissionHook(confirmation));
+        // 每任务独立的重复调用防护（新实例天然隔离，无需 reset）
+        hookRegistry.registerFirst(HookType.PRE_TOOL_USE, new DuplicateToolCallGuard());
         ToolExecutionPipeline toolPipeline = new ToolExecutionPipeline(
                 context, hookRegistry, context.getToolRegistry());
 

--- a/src/main/java/com/thoughtcoding/hook/DuplicateToolCallGuard.java
+++ b/src/main/java/com/thoughtcoding/hook/DuplicateToolCallGuard.java
@@ -1,0 +1,69 @@
+package com.thoughtcoding.hook;
+
+import com.thoughtcoding.model.ToolCall;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 重复工具调用防护 Hook —— Agent 循环死循环兜底。
+ *
+ * <p>拦截"同一消费方连续两次以完全相同的入参调用同一个工具"中的第二次：
+ * 不真正执行工具，直接以报错文本作为 ToolResult 回喂模型（经
+ * {@link com.thoughtcoding.core.ToolExecutionPipeline} 的 PreToolUse BLOCK 短路路径），
+ * 打破模型原地打转。
+ *
+ * <p>注册约定：由各 Agent 循环（AgentLoop / SubAgent）在派生的 HookRegistry 上
+ * registerFirst 注册，且先于 PermissionHook —— 避免对注定被拦的调用重复弹权限确认框。
+ * DirectCommandExecutor 不注册：斜杠命令由用户主动发起，连续重复属合法操作。
+ * AgentLoop 须在每轮用户输入（processInput）开始时调用 {@link #reset()}，
+ * 避免"上一轮的最后一次调用"误拦"下一轮的首次相同调用"。
+ *
+ * <p>线程安全：主 Agent 的并行子代理预执行（虚拟线程）会并发触发本 Hook，
+ * last 状态由同一把锁保护。已知局限：只防"连续重复"（窗口=1），
+ * A,B,A,B 交替循环由 ai.maxToolIterations 兜底。
+ *
+ * <p>异常策略：默认 FAIL_OPEN —— 比较逻辑异常时降级放行，由 maxToolIterations 最终兜底。
+ */
+public class DuplicateToolCallGuard implements Hook {
+
+    /** 回喂模型的核心报错文案（测试按此原文断言）。 */
+    static final String BLOCK_MESSAGE = "不可重复以相同的入参调用同一个工具";
+
+    private final Object lock = new Object();
+    private String lastToolName;
+    private Map<String, Object> lastParameters;
+
+    @Override
+    public HookResult execute(HookContext context) {
+        ToolCall call = context.getToolCall();
+        if (call == null || call.getToolName() == null) {
+            return HookResult.proceed();
+        }
+        // 参数 null 归一化为空 Map；Jackson 产出的 LinkedHashMap 与 HashMap 按 entry 集合互比等价
+        Map<String, Object> parameters = call.getParameters() != null
+                ? call.getParameters() : Map.of();
+
+        synchronized (lock) {
+            if (call.getToolName().equals(lastToolName)
+                    && Objects.equals(parameters, lastParameters)) {
+                return HookResult.block(BLOCK_MESSAGE + " [" + call.getToolName()
+                        + "]。上一次相同调用已执行，请查看其结果，调整入参或改用其他方式，勿原样重试。");
+            }
+            // last = 上次放行的调用。被拦截调用不更新：拦截前提即当前调用与 last 相同，更新与否严格等价。
+            // 快照用 HashMap（容忍 null value，Map.copyOf 会抛 NPE）。
+            lastToolName = call.getToolName();
+            lastParameters = new HashMap<>(parameters);
+        }
+        return HookResult.proceed();
+    }
+
+    /** 清空记忆。每轮用户对话开始时调用，防止跨轮误拦。 */
+    public void reset() {
+        synchronized (lock) {
+            lastToolName = null;
+            lastParameters = null;
+        }
+    }
+}

--- a/src/test/java/com/thoughtcoding/core/ToolExecutionPipelineTest.java
+++ b/src/test/java/com/thoughtcoding/core/ToolExecutionPipelineTest.java
@@ -1,5 +1,6 @@
 package com.thoughtcoding.core;
 
+import com.thoughtcoding.hook.DuplicateToolCallGuard;
 import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.hook.HookResult;
 import com.thoughtcoding.hook.HookType;
@@ -99,6 +100,32 @@ class ToolExecutionPipelineTest {
         assertFalse(outcome.result().isSuccess());
         assertEquals(1, postExecutions.get());
         assertEquals("执行失败: 退出码 1", history.getFirst().getContent());
+    }
+
+    @Test
+    void shouldBlockSecondIdenticalCallAndExecuteToolOnlyOnce() {
+        AtomicInteger executions = new AtomicInteger();
+        ToolRegistry tools = registryWith("echo", input -> {
+            executions.incrementAndGet();
+            return ToolResult.success("完成", 1);
+        });
+        HookRegistry hooks = new HookRegistry()
+                .registerFirst(HookType.PRE_TOOL_USE, new DuplicateToolCallGuard());
+        ToolExecutionPipeline pipeline = new ToolExecutionPipeline(null, hooks, tools);
+        List<ChatMessage> history = new ArrayList<>();
+
+        ToolExecutionPipeline.Outcome first =
+                pipeline.executeAndRecord(call("echo", "call-a"), null, history);
+        ToolExecutionPipeline.Outcome second =
+                pipeline.executeAndRecord(call("echo", "call-b"), null, history);
+
+        assertFalse(first.isBlocked());
+        assertTrue(second.isBlocked());
+        assertTrue(second.result().getError().contains("不可重复以相同的入参调用同一个工具"));
+        assertEquals(1, executions.get());
+        assertEquals(2, history.size());
+        assertEquals("完成", history.getFirst().getContent());
+        assertTrue(history.get(1).getContent().contains("不可重复以相同的入参调用同一个工具"));
     }
 
     private ToolRegistry registryWith(String name, ToolAction action) {

--- a/src/test/java/com/thoughtcoding/hook/DuplicateToolCallGuardTest.java
+++ b/src/test/java/com/thoughtcoding/hook/DuplicateToolCallGuardTest.java
@@ -1,0 +1,153 @@
+package com.thoughtcoding.hook;
+
+import com.thoughtcoding.model.ToolCall;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DuplicateToolCallGuardTest {
+
+    @Test
+    void shouldProceedFirstOccurrenceAndRecordIt() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+
+        HookResult result = guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "git status"))));
+
+        assertFalse(result.isBlocked());
+    }
+
+    @Test
+    void shouldBlockImmediateRepeatWithSameToolAndParams() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "git status"))));
+
+        HookResult repeat = guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "git status"))));
+
+        assertTrue(repeat.isBlocked());
+        assertTrue(repeat.message().contains(DuplicateToolCallGuard.BLOCK_MESSAGE));
+        assertTrue(repeat.message().contains("bash"));
+    }
+
+    @Test
+    void shouldProceedWhenParamsDiffer() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "git status"))));
+
+        assertFalse(guard.execute(HookContext.forPreTool(null, null,
+                call("bash", Map.of("command", "git log")))).isBlocked());
+        assertFalse(guard.execute(HookContext.forPreTool(null, null,
+                call("bash", Map.of("cwd", "/tmp", "command", "git status")))).isBlocked());
+    }
+
+    @Test
+    void shouldProceedWhenToolNameDiffers() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        guard.execute(HookContext.forPreTool(null, null, call("read", Map.of("path", "a.txt"))));
+
+        assertFalse(guard.execute(HookContext.forPreTool(null, null,
+                call("glob", Map.of("path", "a.txt")))).isBlocked());
+    }
+
+    @Test
+    void shouldKeepBlockingConsecutiveRepeatsAfterBlock() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x"))));
+        assertTrue(guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x")))).isBlocked());
+
+        // 原样重试仍持续被拦，直到模型改变入参或换工具
+        assertTrue(guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x")))).isBlocked());
+    }
+
+    @Test
+    void shouldProceedAfterInterleavedDifferentCall() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x"))));
+        assertTrue(guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x")))).isBlocked());
+        guard.execute(HookContext.forPreTool(null, null, call("read", Map.of("path", "a.txt"))));
+
+        // 中间隔了不同的调用 → 不算"连续重复"，放行
+        assertFalse(guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x")))).isBlocked());
+    }
+
+    @Test
+    void shouldProceedAfterReset() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x"))));
+        assertTrue(guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x")))).isBlocked());
+        guard.reset();
+
+        assertFalse(guard.execute(HookContext.forPreTool(null, null, call("bash", Map.of("command", "x")))).isBlocked());
+    }
+
+    @Test
+    void shouldTreatNullParamsAsEmptyMap() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        guard.execute(HookContext.forPreTool(null, null, call("skill", null)));
+
+        assertTrue(guard.execute(HookContext.forPreTool(null, null, call("skill", Map.of()))).isBlocked());
+    }
+
+    @Test
+    void shouldNotBlockWhenContextHasNoToolCall() {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+
+        // toolCall == null 的防御分支（如误注册到非工具时机）
+        assertFalse(guard.execute(HookContext.forStop(null, null)).isBlocked());
+    }
+
+    @Test
+    void shouldFailOpenByDefault() {
+        assertEquals(HookFailurePolicy.FAIL_OPEN, new DuplicateToolCallGuard().failurePolicy());
+    }
+
+    @Test
+    void shouldRemainConsistentUnderConcurrentExecutions() throws Exception {
+        DuplicateToolCallGuard guard = new DuplicateToolCallGuard();
+        int threads = 16;
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger proceeded = new AtomicInteger();
+        List<Thread> workers = new ArrayList<>();
+
+        for (int i = 0; i < threads; i++) {
+            Thread worker = Thread.ofVirtual().unstarted(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                HookResult result = guard.execute(
+                        HookContext.forPreTool(null, null, call("bash", Map.of("command", "same"))));
+                if (!result.isBlocked()) {
+                    proceeded.incrementAndGet();
+                }
+            });
+            workers.add(worker);
+            worker.start();
+        }
+        ready.await();
+        start.countDown();
+        for (Thread worker : workers) {
+            worker.join();
+        }
+
+        // 锁保护下必然恰好放行一次，其余全部拦截
+        assertEquals(1, proceeded.get());
+    }
+
+    private ToolCall call(String toolName, Map<String, Object> parameters) {
+        return new ToolCall(toolName, parameters, null, false, 0, false,
+                UUID.randomUUID().toString());
+    }
+}


### PR DESCRIPTION
## 动机

  Closes #33 

  模型死循环的典型形态是以完全相同入参无限反复调用同一工具，此前只能等 maxToolIterations 硬停。本 PR
  在工具执行层面加兜底：同一消费方连续两次以相同入参调用同一工具时，拦截第二次执行并把报错回喂模型。

  ## 改动

  - **新增 `hook/DuplicateToolCallGuard`**：PreToolUse Hook，记录"上次放行的调用"（工具名 +
  参数快照），连续同参同工具的第二次调用直接 `HookResult.block`。报错经 `ToolExecutionPipeline` 的 BLOCK
  短路路径回喂——不执行工具、POST hook 不触发、`recordResult` 照常写配对结果，**tool call/result 配对不变量不破坏**。
  - **`AgentLoop`**：构造时 `registerFirst` 注册 guard（先于
  PermissionHook，注定被拦的调用不再弹权限确认框）；`processInput` 开头每轮
  `reset()`，跨轮合法重试（用户"再查一次"）不误拦。
  - **`SubAgent`**：`run()` 内每任务新建 guard 实例，任务间天然隔离。
  配对不变量不破坏**。
  - **`AgentLoop`**：构造时 `registerFirst` 注册 guard（先于
  PermissionHook，注定被拦的调用不再弹权限确认框）；`processInput` 开头每轮
  `reset()`，跨轮合法重试（用户"再查一次"）不误拦。
  - **`SubAgent`**：`run()` 内每任务新建 guard 实例，任务间天然隔离。
  - **`DirectCommandExecutor` 有意豁免**：斜杠命令由用户主动发起，连续重复属合法操作。

  ## 设计要点

  - 拦截窗口=1（只防"连续重复"）；被拦调用不更新 last，模型原样重试会持续被拦，直到调整入参或换工具；A,B,A,B
  交替循环由 `maxToolIterations` 兜底（Javadoc 已注明）。
  - 参数比对：`Objects.equals` 直接比参数 Map（结构化、与键序无关），null 归一化为空 Map；快照用 `HashMap`
  拷贝（`Map.copyOf` 遇 null value 会 NPE）。
  - 线程安全：AgentLoop 批内 ≥2 个 subAgent 并行预执行会并发触发同一
  guard，状态由锁保护，并发语义为"恰好放行一个、其余拦截"。
  - FAIL_OPEN：比较逻辑异常时降级放行，不影响正常执行。

  ## 测试

  - 新增 `DuplicateToolCallGuardTest`（11 条：首调放行 / 连续拦截 / 换参放行 / 换工具放行 / 拦后持续拦 /
  交错放行 / reset / null 参数 / 无 toolCall 防御分支 / FAIL_OPEN / 16 虚拟线程并发恰放行 1 次）。
  - `ToolExecutionPipelineTest` 补管线级用例：第二次调用 blocked、底层工具只执行 1 次、history
  恰好两条配对结果。
  - 全部新增用例通过；全量 82 条中 15 个失败（WorktreeManagerTest / DirectCommandExecutorTest /
  ThoughtCodingContextLifecycleTest）已用干净 main worktree 复跑对比，确认为本机环境既有问题，与本改动无关。

  验证：

  ```bash
  mvn test -Dtest=DuplicateToolCallGuardTest,ToolExecutionPipelineTest
  mvn test
  ```
