### PR TITLE
 ⚠️ 请使用 Create a merge commit 方式合并：新增记忆系统（移植自 feature/final_update）+ 取消语义与并发安全修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ sessions/
 # 压缩管线落盘（完整对话 transcript + 大工具结果，不提交）
 transcripts/
 
+# 记忆系统（个人记忆，不提交；如需项目事实随仓库共享可去掉本行）
+.memory/
+
 # 本地配置（不提交）
 config.yaml

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,16 @@ ai:
   perResultPersistBytes: 30000  # L3：触发后只落盘单条超过此字节数的结果，留标记+预览+磁盘路径
   l4KeepTail: 6                 # L4：摘要后接回的最近 N 条
 
+# —— 记忆系统（Memory，非工具）：LLM 驱动 召回注入 / 储存 / 整理 dream ——
+# 存储于 <工作目录>/.memory/（MEMORY.md 索引 + 单条 .md，随项目走）。
+# 索引（name+简介）常驻注入 system prompt；相关记忆全文由 LLM 每轮召回后注入；轮末自动抽取新记忆。
+memory:
+  enabled: true                 # 总开关：加载 .memory/ + 索引注入 + 召回/储存/整理
+  autoExtract: true             # 每轮对话结束后自动抽取新记忆（需一次模型往返，可关）
+  consolidateThreshold: 10      # 记忆文件数达到此值触发 LLM 整合去重（0=禁用）
+  maxIndexEntries: 200          # MEMORY.md 索引条数上限（超限裁掉最早写入的）
+  maxPerTurnInjections: 5       # 单轮自动注入的相关记忆条数上限
+
 tools:
   bash:
     enabled: true

--- a/src/main/java/com/thoughtcoding/config/AppConfig.java
+++ b/src/main/java/com/thoughtcoding/config/AppConfig.java
@@ -29,6 +29,9 @@ public class AppConfig {
     @JsonProperty("ai")
     private AIConfig ai = new AIConfig(); // AI行为配置
 
+    @JsonProperty("memory")
+    private MemoryConfig memory = new MemoryConfig(); // 记忆系统配置
+
 
     // Getters and Setters
     public Map<String, ModelConfig> getModels() {
@@ -67,6 +70,17 @@ public class AppConfig {
 
     public void setAi(AIConfig ai) {
         this.ai = ai;
+    }
+
+    public MemoryConfig getMemory() {
+        if (memory == null) {
+            memory = new MemoryConfig();
+        }
+        return memory;
+    }
+
+    public void setMemory(MemoryConfig memory) {
+        this.memory = memory;
     }
 
 
@@ -416,6 +430,68 @@ public class AppConfig {
 
         public void setL4KeepTail(int l4KeepTail) {
             this.l4KeepTail = l4KeepTail;
+        }
+    }
+
+    /**
+     * 记忆(Memory)系统配置 —— 注意：记忆<b>不作为工具</b>，由 AgentLoop 生命周期编排 +
+     * system prompt 索引注入驱动（见 MemoryService / MemoryStore）。
+     */
+    @Data
+    public static class MemoryConfig {
+        @JsonProperty("enabled")
+        private boolean enabled = true; // 总开关：装配记忆系统（加载 .memory/、注入索引、召回/储存/整理）
+
+        @JsonProperty("autoExtract")
+        private boolean autoExtract = true; // 每轮对话结束后自动抽取新记忆（需一次模型往返，可关）
+
+        @JsonProperty("consolidateThreshold")
+        private int consolidateThreshold = 10; // 记忆文件数达到此值触发 LLM 整合去重（0=禁用）
+
+        @JsonProperty("maxIndexEntries")
+        private int maxIndexEntries = 200; // MEMORY.md 索引条数上限（超限裁掉最早写入的）
+
+        @JsonProperty("maxPerTurnInjections")
+        private int maxPerTurnInjections = 5; // 单轮自动注入的相关记忆条数上限
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isAutoExtract() {
+            return autoExtract;
+        }
+
+        public void setAutoExtract(boolean autoExtract) {
+            this.autoExtract = autoExtract;
+        }
+
+        public int getConsolidateThreshold() {
+            return consolidateThreshold;
+        }
+
+        public void setConsolidateThreshold(int consolidateThreshold) {
+            this.consolidateThreshold = consolidateThreshold;
+        }
+
+        public int getMaxIndexEntries() {
+            return maxIndexEntries;
+        }
+
+        public void setMaxIndexEntries(int maxIndexEntries) {
+            this.maxIndexEntries = maxIndexEntries;
+        }
+
+        public int getMaxPerTurnInjections() {
+            return maxPerTurnInjections;
+        }
+
+        public void setMaxPerTurnInjections(int maxPerTurnInjections) {
+            this.maxPerTurnInjections = maxPerTurnInjections;
         }
     }
 }

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -113,7 +113,8 @@ public class AgentLoop {
             runNativeToolLoop(token);
 
             // ── 记忆：本轮结束后同步储存新记忆 + 触发条件时整理(dream) ──
-            if (memory != null) {
+            // 被取消（stop）的回合不写记忆：半截对话不构成可靠记忆，dream 的整理阈值计数也不应前移
+            if (memory != null && !token.isCancelled()) {
                 memory.remember(history);
                 memory.dream();
             }

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -103,14 +103,13 @@ public class AgentLoop {
 
             history.add(new ChatMessage("user", promptContext.buildPromptForModel()));
 
-            // ── 记忆：本轮开始前 LLM 召回相关记忆，注入 system prompt ──
+            // ── 记忆：本轮开始前 LLM 召回相关记忆；正文沿调用链请求局部传递（同 CancelToken 模式），
+            // 不落 ContextManager 共享字段，避免并行/后台回合互相串写 ──
             MemoryService memory = context.getMemoryService();
-            if (memory != null) {
-                context.getContextManager().setActiveMemories(memory.recall(history));
-            }
+            String recalledMemories = memory != null ? memory.recall(history) : null;
 
             // 原生 function calling：多轮 agentic 循环
-            runNativeToolLoop(token);
+            runNativeToolLoop(token, recalledMemories);
 
             // ── 记忆：本轮结束后同步储存新记忆 + 触发条件时整理(dream) ──
             // 被取消（stop）的回合不写记忆：半截对话不构成可靠记忆，dream 的整理阈值计数也不应前移
@@ -123,7 +122,6 @@ public class AgentLoop {
         } catch (Exception e) {
             context.getUi().displayError("Error processing input: " + e.getMessage());
         } finally {
-            context.getContextManager().clearActiveMemories();
             monitor.stop();
         }
     }
@@ -157,7 +155,7 @@ public class AgentLoop {
      * 补「用户已取消」配对结果，循环退出——保证 history 中的工具调用/结果
      * 严格配对（违反会导致模型 400）。
      */
-    private void runNativeToolLoop(CancelToken token) {
+    private void runNativeToolLoop(CancelToken token, String recalledMemories) {
         AppConfig.AIConfig ai = context.getAppConfig().getAi();
         int maxIter = ai != null ? ai.getMaxToolIterations() : 10;
         boolean auto = ai == null || ai.isAutoProcessToolResults();
@@ -167,7 +165,7 @@ public class AgentLoop {
         while (true) {
             pendingToolCalls.clear();
             // 一轮模型响应（无新用户输入；用户消息与历史已在 history 中）
-            context.getAiService().streamingChat(null, history, modelName, token);
+            context.getAiService().streamingChat(null, history, modelName, token, recalledMemories);
             // 空一行，避免与后续工具确认/结果挤在一起
             context.getUi().getTerminal().writer().println();
             context.getUi().getTerminal().flush();

--- a/src/main/java/com/thoughtcoding/core/AgentLoop.java
+++ b/src/main/java/com/thoughtcoding/core/AgentLoop.java
@@ -4,6 +4,7 @@ import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.hook.HookContext;
 import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.hook.HookResult;
+import com.thoughtcoding.memory.MemoryService;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.model.ToolCall;
 import com.thoughtcoding.model.ToolResult;
@@ -102,13 +103,26 @@ public class AgentLoop {
 
             history.add(new ChatMessage("user", promptContext.buildPromptForModel()));
 
+            // ── 记忆：本轮开始前 LLM 召回相关记忆，注入 system prompt ──
+            MemoryService memory = context.getMemoryService();
+            if (memory != null) {
+                context.getContextManager().setActiveMemories(memory.recall(history));
+            }
+
             // 原生 function calling：多轮 agentic 循环
             runNativeToolLoop(token);
+
+            // ── 记忆：本轮结束后同步储存新记忆 + 触发条件时整理(dream) ──
+            if (memory != null) {
+                memory.remember(history);
+                memory.dream();
+            }
 
             context.getSessionService().saveSession(sessionId, history);
         } catch (Exception e) {
             context.getUi().displayError("Error processing input: " + e.getMessage());
         } finally {
+            context.getContextManager().clearActiveMemories();
             monitor.stop();
         }
     }

--- a/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
+++ b/src/main/java/com/thoughtcoding/core/ThoughtCodingContext.java
@@ -6,6 +6,8 @@ import com.thoughtcoding.config.MCPConfig;
 import com.thoughtcoding.hook.HookRegistry;
 import com.thoughtcoding.mcp.MCPService;
 import com.thoughtcoding.mcp.MCPToolManager;
+import com.thoughtcoding.memory.MemoryService;
+import com.thoughtcoding.memory.MemoryStore;
 import com.thoughtcoding.service.AIService;
 import com.thoughtcoding.service.ContextManager;
 import com.thoughtcoding.service.LangChainService;
@@ -65,6 +67,8 @@ public class ThoughtCodingContext implements AutoCloseable {
 
     // 终端输入路由器（回合后台化后 agent 线程确认框的输入来源；由 AgentTurnRunner 构造时注册）
     private volatile ConsoleInputRouter consoleInputRouter;
+    // 🔥 新增记忆系统（LLM 驱动：召回/储存/整理；非工具）
+    private final MemoryService memoryService;
 
     private ThoughtCodingContext(Builder builder) {
         this.appConfig = builder.appConfig;
@@ -80,6 +84,7 @@ public class ThoughtCodingContext implements AutoCloseable {
         this.mcpToolManager = builder.mcpToolManager;
         this.contextManager = builder.contextManager;
         this.subAgentExecutor = builder.subAgentExecutor;
+        this.memoryService = builder.memoryService;
     }
 
     public static ThoughtCodingContext initialize() {
@@ -135,7 +140,23 @@ public class ThoughtCodingContext implements AutoCloseable {
         }
 
         // 服务层初始化
-        ContextManager contextManager = new ContextManager(appConfig, skillRegistry);  // 🔥 创建上下文管理器
+        // ── 记忆系统（非工具）：LLM 驱动召回/储存/整理；memory.enabled=false 或内存分配失败则整体为 null ──
+        AppConfig.MemoryConfig memCfg = appConfig.getMemory();
+        MemoryStore memoryStore = null;
+        MemoryService memoryService = null;
+        if (memCfg != null && memCfg.isEnabled()) {
+            try {
+                memoryStore = MemoryStore.load(
+                        java.nio.file.Paths.get(System.getProperty("user.dir"), ".memory"),
+                        memCfg.getMaxIndexEntries());
+                memoryService = new MemoryService(appConfig, memoryStore, memCfg);
+            } catch (Exception e) {
+                // 记忆系统初始化失败不阻塞主对话
+                memoryStore = null;
+                memoryService = null;
+            }
+        }
+        ContextManager contextManager = new ContextManager(appConfig, skillRegistry, memoryStore);  // 🔥 创建上下文管理器
         AIService aiService = new LangChainService(appConfig, toolRegistry, contextManager);  // 🔥 注入 contextManager
         SessionService sessionService = new SessionService();
         PerformanceMonitor performanceMonitor = new PerformanceMonitor();
@@ -161,6 +182,7 @@ public class ThoughtCodingContext implements AutoCloseable {
                 .mcpToolManager(mcpToolManager)
                 .contextManager(contextManager)  // 🔥 添加 contextManager
                 .subAgentExecutor(subAgentExecutor)
+                .memoryService(memoryService)   // 🔥 添加 memoryService（可为 null = 记忆关闭）
                 .build();
 
         try {
@@ -381,6 +403,9 @@ public class ThoughtCodingContext implements AutoCloseable {
     public SubAgentExecutor getSubAgentExecutor() { return subAgentExecutor; }
     public ConsoleInputRouter getConsoleInputRouter() { return consoleInputRouter; }
     public void setConsoleInputRouter(ConsoleInputRouter router) { this.consoleInputRouter = router; }
+
+    // 🔥 新增 memoryService Getter（可为 null = 记忆功能关闭）
+    public MemoryService getMemoryService() { return memoryService; }
     public ThoughtCodingUI getUi() { return ui; }
     public PerformanceMonitor getPerformanceMonitor() { return performanceMonitor; }
     public HookRegistry getHookRegistry() { return hookRegistry; }
@@ -433,6 +458,8 @@ public class ThoughtCodingContext implements AutoCloseable {
         private ContextManager contextManager;
         // 🔥 并行/后台子代理调度器
         private SubAgentExecutor subAgentExecutor;
+        // 🔥 新增记忆系统字段
+        private MemoryService memoryService;
 
         public Builder appConfig(AppConfig appConfig) {
             this.appConfig = appConfig;
@@ -494,6 +521,11 @@ public class ThoughtCodingContext implements AutoCloseable {
         // 🔥 子代理调度器 Builder 方法
         public Builder subAgentExecutor(SubAgentExecutor subAgentExecutor) {
             this.subAgentExecutor = subAgentExecutor;
+            return this;
+        }
+        // 🔥 新增 memoryService Builder 方法
+        public Builder memoryService(MemoryService memoryService) {
+            this.memoryService = memoryService;
             return this;
         }
 

--- a/src/main/java/com/thoughtcoding/memory/MemoryService.java
+++ b/src/main/java/com/thoughtcoding/memory/MemoryService.java
@@ -95,7 +95,8 @@ public class MemoryService {
 
         String catalog = buildCatalog();
         String prompt = "给定下面的最近对话和记忆目录，挑选其中<b>明确相关</b>的记忆条目的索引号。"
-                + "只返回一个 JSON 数组，例如 [0, 3]；都不相关则返回 []。\n\n"
+                + "只返回一个 JSON 数组，例如 [0, 3]；都不相关则返回 []。"
+                + "索引必须是记忆目录中真实存在的编号（范围 0 到 N-1，N 为目录条数），不要返回越界的索引。\n\n"
                 + "最近对话:\n" + recent + "\n\n"
                 + "记忆目录:\n" + catalog;
 

--- a/src/main/java/com/thoughtcoding/memory/MemoryService.java
+++ b/src/main/java/com/thoughtcoding/memory/MemoryService.java
@@ -1,0 +1,416 @@
+package com.thoughtcoding.memory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtcoding.config.AppConfig;
+import com.thoughtcoding.model.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 记忆系统的 LLM 大脑：召回注入(recall) / 储存(remember) / 整理 dream(consolidate)。
+ *
+ * <p>三件事全部<b>由 LLM 驱动</b>（与 s09_memory.py 的 memory 设计对齐），且<b>不作为工具</b>——
+ * 它们由 {@code AgentLoop} 生命周期编排，模型永远不会看到记忆工具。
+ *
+ * <ul>
+ *   <li>{@link #recall}：取最近对话，让 LLM 从记忆索引里挑相关条目，把完整正文注入本轮 system prompt。</li>
+ *   <li>{@link #remember}：每轮结束，让 LLM 从对话里抽取新记忆（对现有记忆去重后落盘）。</li>
+ *   <li>{@link #dream}：记忆文件数达到阈值时，让 LLM 整合/合并/清理全部记忆。</li>
+ * </ul>
+ *
+ * <p>使用<b>独立的同步模型实例</b>（仿 {@code ContextManager} 的 L4 摘要模型），不触碰
+ * {@code LangChainService} 的共享流式状态——见 [[subagent-isolation-constraint]]。
+ * 所有公开方法<b>永不抛出</b>：记忆失败绝不能中断对话。
+ */
+public class MemoryService {
+    private static final Logger log = LoggerFactory.getLogger(MemoryService.class);
+
+    private static final Pattern JSON_ARRAY = Pattern.compile("\\[.*\\]", Pattern.DOTALL);
+
+    private final MemoryStore store;
+    private final boolean autoExtract;
+    private final int consolidateThreshold;
+    private final int maxIndexEntries;
+    private final int maxPerTurnInjections;
+    private final OpenAiChatModel model; // 独立同步模型（null = 模型不可用 → 记忆功能静默降级）
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public MemoryService(AppConfig appConfig, MemoryStore store, AppConfig.MemoryConfig config) {
+        this.store = store;
+        this.autoExtract = config != null && config.isAutoExtract();
+        this.consolidateThreshold = config != null ? config.getConsolidateThreshold() : 10;
+        this.maxIndexEntries = config != null ? config.getMaxIndexEntries() : 200;
+        this.maxPerTurnInjections = config != null ? config.getMaxPerTurnInjections() : 5;
+        this.model = buildModel(appConfig);
+    }
+
+    /** 独立同步模型：与主模型同源。构建失败 → null（记忆功能静默降级，不阻塞主对话）。 */
+    private OpenAiChatModel buildModel(AppConfig appConfig) {
+        try {
+            AppConfig.ModelConfig modelConfig = appConfig.getModelConfig(appConfig.getDefaultModel());
+            if (modelConfig == null) {
+                return null;
+            }
+            return OpenAiChatModel.builder()
+                    .baseUrl(modelConfig.getBaseURL())
+                    .apiKey(modelConfig.getApiKey())
+                    .modelName(modelConfig.getName())
+                    .temperature(modelConfig.getTemperature())
+                    .maxTokens(modelConfig.getMaxTokens())
+                    .logRequests(false)
+                    .logResponses(false)
+                    .build();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // 召回（recall）：选相关记忆，把完整正文注入本轮
+    // ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 从历史里挑最近几条用户消息作为上下文，让 LLM 从记忆目录里选出相关条目，
+     * 返回其完整正文（包在 {@code <relevant_memories>} 里）。返回空串表示无可注入内容。
+     * 空库直接返回空串（省一次无谓的模型往返）。任何失败退化为关键词匹配。
+     */
+    public String recall(List<ChatMessage> history) {
+        if (store == null || store.isEmpty() || model == null) {
+            return "";
+        }
+        String recent = recentUserText(history, 2000);
+        if (recent.isBlank()) {
+            return "";
+        }
+
+        String catalog = buildCatalog();
+        String prompt = "给定下面的最近对话和记忆目录，挑选其中<b>明确相关</b>的记忆条目的索引号。"
+                + "只返回一个 JSON 数组，例如 [0, 3]；都不相关则返回 []。\n\n"
+                + "最近对话:\n" + recent + "\n\n"
+                + "记忆目录:\n" + catalog;
+
+        List<Integer> selected = null;
+        try {
+            selected = parseIndexArray(callLlm(prompt));
+        } catch (Exception ignored) {
+            selected = null;
+        }
+
+        // 失败退化为关键词匹配（对 name+description）
+        if (selected == null) {
+            selected = keywordFallback(recent);
+        }
+
+        if (selected.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder("<relevant_memories>\n");
+        int count = 0;
+        for (int idx : selected) {
+            if (count >= maxPerTurnInjections) {
+                break;
+            }
+            List<MemoryStore.Memory> list = store.list();
+            if (idx < 0 || idx >= list.size()) {
+                continue;
+            }
+            sb.append(list.get(idx).body()).append("\n\n");
+            count++;
+        }
+        sb.append("</relevant_memories>");
+        return sb.toString().stripTrailing();
+    }
+
+    private String buildCatalog() {
+        StringBuilder sb = new StringBuilder();
+        List<MemoryStore.Memory> list = store.list();
+        for (int i = 0; i < list.size(); i++) {
+            MemoryStore.Memory m = list.get(i);
+            sb.append(i).append(": ").append(m.name()).append(" — ").append(m.description()).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private List<Integer> keywordFallback(String recent) {
+        Set<String> keywords = new LinkedHashSet<>();
+        for (String w : recent.toLowerCase().split("\\s+")) {
+            if (w.length() > 3) {
+                keywords.add(w);
+            }
+        }
+        List<Integer> selected = new ArrayList<>();
+        List<MemoryStore.Memory> list = store.list();
+        for (int i = 0; i < list.size() && selected.size() < maxPerTurnInjections; i++) {
+            MemoryStore.Memory m = list.get(i);
+            String hay = (m.name() + " " + m.description()).toLowerCase();
+            for (String kw : keywords) {
+                if (hay.contains(kw)) {
+                    selected.add(i);
+                    break;
+                }
+            }
+        }
+        return selected;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // 储存（remember）：每轮结束抽取新记忆
+    // ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 从最近对话抽取新记忆。autoExtract 关闭或模型不可用则直接跳过。
+     * 让 LLM 对照现有记忆去重后返回 {@code [{name,type,description,body}]}；无新增返回 []。
+     */
+    public void remember(List<ChatMessage> history) {
+        if (!autoExtract || model == null || store == null) {
+            return;
+        }
+        String dialogue = recentDialogue(history, 4000);
+        if (dialogue.isBlank()) {
+            return;
+        }
+
+        String existing = existingCatalog();
+        String prompt = "从这段对话中抽取用户偏好、约束或项目事实，整理成记忆。\n"
+                + "返回一个 JSON 数组，每项含四个字段:\n"
+                + "- name: 简短 kebab-case 标识（如 user-preference-tabs）\n"
+                + "- type: user（用户偏好）/ feedback（反馈约定）/ project（项目事实）/ reference（外部指引）\n"
+                + "- description: 一行摘要，供索引查找\n"
+                + "- body: Markdown 全文细节\n"
+                + "已被现有记忆覆盖的、或没有持久价值的内容不要抽取；没有新记忆时返回 []。\n\n"
+                + "现有记忆:\n" + existing + "\n\n"
+                + "对话:\n" + dialogue;
+
+        try {
+            String text = callLlm(prompt);
+            List<Object> items = extractJsonArray(text);
+            if (items == null || items.isEmpty()) {
+                return;
+            }
+            int written = 0;
+            for (Object itemObj : items) {
+                if (!(itemObj instanceof java.util.Map<?, ?> map)) {
+                    continue;
+                }
+                Object name = map.get("name");
+                Object type = map.get("type");
+                Object desc = map.get("description");
+                Object body = map.get("body");
+                if (name == null || name.toString().isBlank()) {
+                    continue;
+                }
+                String descStr = desc == null ? "" : desc.toString().trim();
+                String bodyStr = body == null ? "" : body.toString().trim();
+                if (descStr.isEmpty() && bodyStr.isEmpty()) {
+                    continue;
+                }
+                String typeStr = type == null ? "user" : type.toString().trim();
+                store.write(name.toString().trim(), typeStr, descStr, bodyStr);
+                written++;
+            }
+            if (written > 0) {
+                System.out.println("\n[33m[Memory: extracted " + written + " new memories][0m");
+            }
+        } catch (Exception e) {
+            log.warn("记忆抽取失败（不影响对话）: {}", e.getMessage());
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // 整理（dream）：记忆多了之后整合去重
+    // ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 记忆文件数达到阈值时，让 LLM 合并重复、清理过时、保留用户偏好，然后整体替换。
+     * consolidateThreshold <= 0 或数量不足则跳过；任何失败都静默，保留原记忆不丢。
+     */
+    public void dream() {
+        if (store == null || model == null || store.isEmpty()) {
+            return;
+        }
+        if (consolidateThreshold <= 0 || store.size() < consolidateThreshold) {
+            return;
+        }
+
+        StringBuilder catalog = new StringBuilder();
+        for (MemoryStore.Memory m : store.list()) {
+            catalog.append("## ").append(m.filename()).append('\n');
+            catalog.append("name: ").append(m.name()).append('\n');
+            catalog.append("description: ").append(m.description()).append('\n');
+            catalog.append(m.body()).append("\n\n");
+        }
+        String prompt = "整合下面这些记忆文件:\n"
+                + "1. 重复的合并为一条\n"
+                + "2. 删除过时/被推翻的记忆\n"
+                + "3. 总数控制在 30 条以内\n"
+                + "4. 用户偏好（type=user）优先保留\n"
+                + "返回一个 JSON 数组，每项 {name, type, description, body}。\n\n"
+                + catalog;
+        // 记忆目录很长时截断，避免超模型输出上限；截断只影响本次整合质量，不丢记忆
+        if (prompt.length() > 16000) {
+            prompt = prompt.substring(0, 16000) + "\n...(已截断)";
+        }
+
+        try {
+            String text = callLlm(prompt);
+            List<Object> items = extractJsonArray(text);
+            if (items == null || items.isEmpty()) {
+                return;
+            }
+            List<MemoryStore.Memory> next = new ArrayList<>();
+            for (Object itemObj : items) {
+                if (!(itemObj instanceof java.util.Map<?, ?> map)) {
+                    continue;
+                }
+                Object name = map.get("name");
+                Object type = map.get("type");
+                Object desc = map.get("description");
+                Object body = map.get("body");
+                if (name == null || name.toString().isBlank()) {
+                    continue;
+                }
+                String descStr = desc == null ? "" : desc.toString().trim();
+                String bodyStr = body == null ? "" : body.toString().trim();
+                if (descStr.isEmpty() && bodyStr.isEmpty()) {
+                    continue;
+                }
+                String typeStr = type == null ? "user" : type.toString().trim();
+                next.add(new MemoryStore.Memory("", name.toString().trim(), descStr, typeStr, bodyStr));
+            }
+            if (next.isEmpty()) {
+                return;
+            }
+            int before = store.size();
+            store.replaceAll(next);
+            System.out.println("\n[33m[Memory: consolidated " + before + " → " + next.size() + " memories][0m");
+        } catch (Exception e) {
+            log.warn("记忆整合失败（保留原记忆，不影响对话）: {}", e.getMessage());
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // 辅助
+    // ────────────────────────────────────────────────────────────────────────
+
+    private String existingCatalog() {
+        if (store == null || store.isEmpty()) {
+            return "(无)";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (MemoryStore.Memory m : store.list()) {
+            sb.append("- ").append(m.name()).append(": ").append(m.description()).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private String recentUserText(List<ChatMessage> history, int maxChars) {
+        if (history == null) {
+            return "";
+        }
+        List<String> texts = new ArrayList<>();
+        for (int i = history.size() - 1; i >= 0 && texts.size() < 3; i--) {
+            ChatMessage msg = history.get(i);
+            if (msg != null && msg.isUserMessage()) {
+                String c = msg.getContent();
+                if (c != null && !c.isBlank()) {
+                    texts.add(c);
+                }
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = texts.size() - 1; i >= 0; i--) {
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append(texts.get(i));
+        }
+        String joined = sb.toString();
+        return joined.length() <= maxChars ? joined : joined.substring(0, maxChars);
+    }
+
+    private String recentDialogue(List<ChatMessage> history, int maxChars) {
+        if (history == null) {
+            return "";
+        }
+        List<String> lines = new ArrayList<>();
+        int from = Math.max(0, history.size() - 10);
+        for (int i = from; i < history.size(); i++) {
+            ChatMessage msg = history.get(i);
+            if (msg == null) {
+                continue;
+            }
+            if (msg.isToolMessage()) {
+                continue; // 工具结果不参与抽取
+            }
+            String c = msg.getContent();
+            if (c == null || c.isBlank()) {
+                continue;
+            }
+            lines.add(msg.getRole() + ": " + c);
+        }
+        String joined = String.join("\n", lines);
+        return joined.length() <= maxChars ? joined : joined.substring(0, maxChars);
+    }
+
+    /** 同步 LLM 调用，失败返回 null（调用方各自降级）。 */
+    private String callLlm(String prompt) {
+        try {
+            ChatResponse response = model.chat(UserMessage.from(prompt));
+            return response.aiMessage().text();
+        } catch (Exception e) {
+            log.warn("记忆模型调用失败: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /** 从响应里解析整数索引数组（recall 用）。 */
+    private List<Integer> parseIndexArray(String text) {
+        if (text == null) {
+            return null;
+        }
+        Matcher m = JSON_ARRAY.matcher(text);
+        if (!m.find()) {
+            return null;
+        }
+        try {
+            java.util.List<?> arr = objectMapper.readValue(m.group(), java.util.List.class);
+            List<Integer> out = new ArrayList<>();
+            for (Object o : arr) {
+                if (o instanceof Number n) {
+                    out.add(n.intValue());
+                }
+            }
+            return out;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** 从响应里解析对象数组（remember/dream 用）。 */
+    @SuppressWarnings("unchecked")
+    private List<Object> extractJsonArray(String text) {
+        if (text == null) {
+            return null;
+        }
+        Matcher m = JSON_ARRAY.matcher(text);
+        if (!m.find()) {
+            return null;
+        }
+        try {
+            Object parsed = objectMapper.readValue(m.group(), Object.class);
+            return parsed instanceof java.util.List<?> list ? new ArrayList<>(list) : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/thoughtcoding/memory/MemoryService.java
+++ b/src/main/java/com/thoughtcoding/memory/MemoryService.java
@@ -232,7 +232,8 @@ public class MemoryService {
 
     /**
      * 记忆文件数达到阈值时，让 LLM 合并重复、清理过时、保留用户偏好，然后整体替换。
-     * consolidateThreshold <= 0 或数量不足则跳过；任何失败都静默，保留原记忆不丢。
+     * <b>目标上限就是 {@code consolidateThreshold}</b>（配置的触发阈值兼作 dream 压缩到的条数上限，
+     * 会写进 prompt 告诉 LLM）。任何失败都静默，保留原记忆不丢。
      */
     public void dream() {
         if (store == null || model == null || store.isEmpty()) {
@@ -249,10 +250,12 @@ public class MemoryService {
             catalog.append("description: ").append(m.description()).append('\n');
             catalog.append(m.body()).append("\n\n");
         }
+        // 目标条数 = consolidateThreshold（配置的触发阈值兼作 dream 的目标上限）
+        int targetCount = Math.max(1, consolidateThreshold);
         String prompt = "整合下面这些记忆文件:\n"
                 + "1. 重复的合并为一条\n"
                 + "2. 删除过时/被推翻的记忆\n"
-                + "3. 总数控制在 30 条以内\n"
+                + "3. 总数控制在 " + targetCount + " 条以内（若本来就少于 " + targetCount + " 条，保持不变即可）\n"
                 + "4. 用户偏好（type=user）优先保留\n"
                 + "返回一个 JSON 数组，每项 {name, type, description, body}。\n\n"
                 + catalog;

--- a/src/main/java/com/thoughtcoding/memory/MemoryStore.java
+++ b/src/main/java/com/thoughtcoding/memory/MemoryStore.java
@@ -1,0 +1,278 @@
+package com.thoughtcoding.memory;
+
+import com.thoughtcoding.util.FileUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 记忆(Memory)存储层 —— 仿 {@code SkillRegistry} 的 frontmatter 解析，但<b>可变</b>（运行时写入/整理）。
+ *
+ * <p>目录结构（仿 Claude Code 的 memory）：
+ * <pre>
+ *   .memory/
+ *     MEMORY.md            ← 索引（每行一条：{@code - [name](file) — description}），常驻注入 system prompt
+ *     *.md                 ← 单条记忆文件（Markdown + YAML frontmatter：name/description/type）
+ * </pre>
+ *
+ * <p>{@code type} ∈ user（用户偏好）/ feedback（反馈约定）/ project（项目事实）/ reference（外部指引）。
+ * 本类<b>不做任何 LLM 调用</b>——召回/抽取/整理的大脑在 {@link MemoryService}。任何文件操作失败都降级、不抛。
+ */
+public final class MemoryStore {
+
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    /** frontmatter 块：开头 ---，正文前再一个 ---（\R 兼容 \n 与 \r\n）。 */
+    private static final Pattern FRONTMATTER =
+            Pattern.compile("\\A---\\s*\\R(.*?)\\R---\\s*\\R?(.*)\\z", Pattern.DOTALL);
+
+    /** 索引文件恒定的名字（不在记忆文件集合里）。 */
+    public static final String INDEX_FILE = "MEMORY.md";
+
+    /** 合法记忆类型（frontmatter 里的 type 非法时回退为 user）。 */
+    public static final List<String> MEMORY_TYPES = List.of("user", "feedback", "project", "reference");
+
+    /** 单条记忆：filename 用于索引/读取，name/description 用于目录展示，type 用于分类，body 为正文。 */
+    public record Memory(String filename, String name, String description, String type, String body) {
+    }
+
+    private final Path dir;
+    private final int maxIndexEntries;
+    private final Map<String, Memory> memories; // filename → Memory，写入序即展示序
+
+    private MemoryStore(Path dir, int maxIndexEntries, Map<String, Memory> memories) {
+        this.dir = dir;
+        this.maxIndexEntries = maxIndexEntries;
+        this.memories = memories;
+    }
+
+    /**
+     * 加载（或创建）记忆目录。目录不存在则 {@code createDirectories} 后视为空库。
+     * 解析/列举失败不阻塞——降级为空库。返回的实例可直接用 {@link #write}/{@link #replaceAll} 修改。
+     */
+    public static MemoryStore load(Path dir, int maxIndexEntries) {
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException ignored) {
+            // 目录创建失败 → 降级为空库（后续写操作也会各自失败降级）
+        }
+        Map<String, Memory> map = new LinkedHashMap<>();
+        if (dir != null && Files.isDirectory(dir)) {
+            try (var stream = Files.list(dir)) {
+                List<Path> files = stream.filter(Files::isRegularFile).sorted().toList();
+                for (Path file : files) {
+                    String filename = file.getFileName().toString();
+                    if (INDEX_FILE.equals(filename)) {
+                        continue;
+                    }
+                    try {
+                        String raw = Files.readString(file);
+                        Memory m = parse(filename, raw);
+                        map.put(filename, m);
+                    } catch (Exception ignored) {
+                        // 单条记忆解析失败不阻塞其余记忆加载
+                    }
+                }
+            } catch (IOException ignored) {
+                // 目录列举失败 → 降级为空库
+            }
+        }
+        return new MemoryStore(dir, maxIndexEntries, map);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Memory parse(String filename, String raw) {
+        String name = filename.replaceFirst("\\.md$", "");
+        String description = null;
+        String type = "user";
+        String body = raw;
+
+        Matcher m = FRONTMATTER.matcher(raw);
+        if (m.matches()) {
+            String fm = m.group(1);
+            body = m.group(2);
+            try {
+                Map<String, Object> meta = YAML_MAPPER.readValue(fm, Map.class);
+                Object n = meta.get("name");
+                if (n != null && !n.toString().isBlank()) {
+                    name = n.toString().trim();
+                }
+                Object d = meta.get("description");
+                if (d != null && !d.toString().isBlank()) {
+                    description = d.toString().trim();
+                }
+                Object t = meta.get("type");
+                if (t != null && MEMORY_TYPES.contains(t.toString().trim())) {
+                    type = t.toString().trim();
+                }
+            } catch (Exception ignored) {
+                // frontmatter 非法 YAML → 忽略元数据，整份原文当正文
+                body = raw;
+            }
+        }
+
+        if (description == null || description.isBlank()) {
+            description = firstNonBlankLine(body);
+        }
+
+        return new Memory(filename, name, description, type, body.strip());
+    }
+
+    private static String firstNonBlankLine(String body) {
+        for (String line : body.split("\n")) {
+            String t = line.strip();
+            if (!t.isEmpty()) {
+                return t.replaceFirst("^#+\\s*", "");
+            }
+        }
+        return "";
+    }
+
+    /**
+     * 写入一条记忆。slugify name 得文件名（{@code <slug>.md}），frontmatter 与正文一起落盘，
+     * 更新内存 map 并重建索引。失败返回 null（调用方静默忽略），不抛。
+     */
+    public Path write(String name, String type, String description, String body) {
+        try {
+            String slug = name.toLowerCase().replaceAll("[^a-z0-9]+", "-").replaceAll("(^-|-$)", "");
+            if (slug.isBlank()) {
+                slug = "memory-" + System.nanoTime();
+            }
+            String filename = slug + ".md";
+            String typeVal = (type != null && MEMORY_TYPES.contains(type)) ? type : "user";
+            String content = "---\n"
+                    + "name: " + name + "\n"
+                    + "description: " + (description == null ? "" : description) + "\n"
+                    + "type: " + typeVal + "\n"
+                    + "---\n\n"
+                    + (body == null ? "" : body.strip()) + "\n";
+            Path target = dir.resolve(filename);
+            FileUtils.writeFile(target, content);
+            memories.put(filename, new Memory(filename, name, description == null ? "" : description, typeVal, body == null ? "" : body.strip()));
+            rebuildIndexFile();
+            return target;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * 整理(Dream)用：整体替换全部记忆（去重/合并/清理后的结果），并重建索引。
+     *
+     * <p>顺序不可换：<b>先写全部新文件（覆盖同名、创建新名）→ 全部成功后才删旧文件</b>——
+     * 删除循环只删「不在新集合 {@code next.keySet()} 里的」旧文件，<b>刚写入的新文件绝不在删除范围</b>，
+     * 修复了旧实现「写完再全删」会连带删掉新文件（尤其是 dream 新增了旧记忆没有的名字时）的 bug。
+     * 任一写失败则返回、不进入删除，保留既有记忆不丢。
+     */
+    public void replaceAll(List<Memory> newMemories) {
+        if (newMemories == null) {
+            return;
+        }
+        // 1. 先在内存里算好全部目标文件（filename → 内容）与目标集合，避免边写边决定
+        Map<String, String> contents = new LinkedHashMap<>();
+        Map<String, Memory> next = new LinkedHashMap<>();
+        for (Memory m : newMemories) {
+            if (m == null || m.name() == null || m.name().isBlank()) {
+                continue;
+            }
+            String slug = m.name().toLowerCase().replaceAll("[^a-z0-9]+", "-").replaceAll("(^-|-$)", "");
+            if (slug.isBlank()) {
+                slug = "memory-" + System.nanoTime();
+            }
+            String filename = slug + ".md";
+            String typeVal = (m.type() != null && MEMORY_TYPES.contains(m.type())) ? m.type() : "user";
+            contents.put(filename, "---\n"
+                    + "name: " + m.name() + "\n"
+                    + "description: " + (m.description() == null ? "" : m.description()) + "\n"
+                    + "type: " + typeVal + "\n"
+                    + "---\n\n"
+                    + (m.body() == null ? "" : m.body().strip()) + "\n");
+            next.put(filename, new Memory(filename, m.name(), m.description() == null ? "" : m.description(),
+                    typeVal, m.body() == null ? "" : m.body().strip()));
+        }
+
+        // 2. 先写全部新文件（覆盖同名、创建新名）；任一失败 → 不进入删除，保留旧记忆
+        for (Map.Entry<String, String> e : contents.entrySet()) {
+            try {
+                FileUtils.writeFile(dir.resolve(e.getKey()), e.getValue());
+            } catch (Exception ex) {
+                return;
+            }
+        }
+
+        // 3. 全部写成功后，只删「不在新集合里」的旧文件（新文件/保留的同名文件都不在删除范围）
+        try {
+            try (var stream = Files.list(dir)) {
+                for (Path file : (Iterable<Path>) stream.filter(Files::isRegularFile).toList()) {
+                    String filename = file.getFileName().toString();
+                    if (!INDEX_FILE.equals(filename) && !next.containsKey(filename)) {
+                        Files.deleteIfExists(file);
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            // 清理失败不影响新集合生效
+        }
+
+        // 4. 清 map、替换、重建索引
+        memories.clear();
+        memories.putAll(next);
+        rebuildIndexFile();
+    }
+
+    /** 重建 MEMORY.md 索引（受 maxIndexEntries 上限，超限裁掉最早写入的）。 */
+    public void rebuildIndexFile() {
+        try {
+            List<String> lines = new ArrayList<>();
+            for (Memory m : memories.values()) {
+                if (lines.size() >= maxIndexEntries) {
+                    break;
+                }
+                lines.add("- [" + m.name() + "](" + m.filename() + ") — " + m.description());
+            }
+            FileUtils.writeFile(dir.resolve(INDEX_FILE), String.join("\n", lines) + (lines.isEmpty() ? "" : "\n"));
+        } catch (Exception ignored) {
+            // 索引重建失败不抛
+        }
+    }
+
+    /** 索引文本（供 system prompt 注入），受 maxIndexEntries 上限。 */
+    public String index() {
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        for (Memory m : memories.values()) {
+            if (count >= maxIndexEntries) {
+                break;
+            }
+            sb.append("- [").append(m.name()).append("](").append(m.filename())
+                    .append(") — ").append(m.description()).append('\n');
+            count++;
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    public List<Memory> list() {
+        return List.copyOf(memories.values());
+    }
+
+    public Memory get(String filename) {
+        return memories.get(filename);
+    }
+
+    public int size() {
+        return memories.size();
+    }
+
+    public boolean isEmpty() {
+        return memories.isEmpty();
+    }
+}

--- a/src/main/java/com/thoughtcoding/service/AIService.java
+++ b/src/main/java/com/thoughtcoding/service/AIService.java
@@ -70,4 +70,16 @@ public interface AIService {
                                             com.thoughtcoding.core.CancelToken token) {
         return streamingChat(input, history, modelName);
     }
+
+    /**
+     * 同 {@link #streamingChat(String, List, String, CancelToken)}，另带本轮召回的记忆正文：
+     * 由调用方（AgentLoop）沿调用链请求局部传递并注入消息尾部，不落共享可变状态，
+     * 避免并行/后台回合串写。recalledMemories 为 null/blank 等价于无召回。
+     */
+    default List<ChatMessage> streamingChat(String input, List<ChatMessage> history,
+                                            String modelName,
+                                            com.thoughtcoding.core.CancelToken token,
+                                            String recalledMemories) {
+        return streamingChat(input, history, modelName, token);
+    }
 }

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -541,6 +541,9 @@ public class ContextManager {
             sb.append("以下是你长期记住的用户偏好/项目事实/反馈约定（跨会话保留）。\n");
             sb.append("对话中出现相关话题时，应优先遵守其中的用户偏好。\n");
             sb.append(memoryStore.index()).append("\n");
+            sb.append("\n重要：这些记忆文件由记忆系统自动管理（轮次间自动抽取 remember、到达阈值自动整理 dream）。\n");
+            sb.append("【禁止】用 write / edit / bash 等任何工具直接创建、修改、删除 .memory/ 目录下的记忆文件；\n");
+            sb.append("如需新增或更新记忆，直接告知用户，由记忆系统自动完成，无需也不应手动操作这些文件。\n");
         }
     }
 

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -528,8 +528,12 @@ public class ContextManager {
     }
 
     /**
-     * 记忆目录（名称+简介）常驻注入 system prompt，零额外 API 调用；
-     * 相关记忆的完整正文由 AgentLoop 每轮通过 {@link #setActiveMemories} 注入（LLM 召回）。
+     * 记忆目录（名称+简介）常驻注入 system prompt，零额外 API 调用；相对稳定（仅 remember/dream 写入时才变）。
+     *
+     * <p>注意：本轮召回的<b>相关记忆正文</b>（每轮都不同）<b>不</b>放这里——它由
+     * {@link #buildRecallReminder()} 包成 {@code <system-reminder>}，经 {@code LangChainService.prepareMessages}
+     * 注入到<b>消息列表尾部</b>（贴当前轮）。这样每轮易变的召回只动尾巴，不冲掉「system 前缀 + 历史」的前缀缓存
+     * （仿 Claude Code 把易变上下文贴当前用户轮，而非塞进被缓存的 system 前缀）。
      */
     private void appendMemory(StringBuilder sb) {
         if (memoryStore != null && !memoryStore.isEmpty()) {
@@ -538,19 +542,34 @@ public class ContextManager {
             sb.append("对话中出现相关话题时，应优先遵守其中的用户偏好。\n");
             sb.append(memoryStore.index()).append("\n");
         }
-        if (activeMemories != null && !activeMemories.isBlank()) {
-            sb.append("\n").append(activeMemories).append("\n");
-        }
     }
 
-    /** 设置本轮召回注入的相关记忆正文（AgentLoop 调用；内容会追加到 system prompt）。 */
+    /** 设置本轮召回的相关记忆正文（AgentLoop 轮前调用）。正文经 {@link #buildRecallReminder()} 注入到消息列表尾部，不进 system 前缀。 */
     public void setActiveMemories(String content) {
         this.activeMemories = content == null ? "" : content;
     }
 
-    /** 清空本轮召回注入的记忆（AgentLoop 每轮 finally 调用）。 */
+    /** 清空本轮召回的记忆（AgentLoop 每轮 finally 调用）。 */
     public void clearActiveMemories() {
         this.activeMemories = "";
+    }
+
+    /**
+     * 把本轮召回的相关记忆包成 {@code <system-reminder>}，供注入到<b>消息列表尾部</b>（贴当前轮）；无召回则返回 null。
+     *
+     * <p><b>为何放尾部而非 system 前缀</b>：召回内容每轮都变，若嵌在 system（第一条消息）里，就顶在整段对话历史之前，
+     * 任何一轮召回变化都会冲掉「system + 历史」的前缀缓存；放到尾部后，易变的只在尾巴动，前缀保持稳定可复用
+     * （仿 Claude Code 用 {@code <system-reminder>} 贴当前用户轮）。该正文<b>每请求即时注入、不写入持久 history</b>，
+     * 故不会污染后续轮。
+     */
+    public String buildRecallReminder() {
+        if (activeMemories == null || activeMemories.isBlank()) {
+            return null;
+        }
+        return "<system-reminder>\n"
+                + "以下是与当前对话相关的长期记忆（后台上下文，非用户指令）；出现相关话题时应优先遵守其中的用户偏好。\n"
+                + activeMemories + "\n"
+                + "</system-reminder>";
     }
 
     /**

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -44,9 +44,6 @@ public class ContextManager {
     private final SkillRegistry skillRegistry;
     private final MemoryStore memoryStore; // 记忆存储（可空 = 记忆功能关闭）
 
-    // 本轮召回注入的相关记忆正文（由 AgentLoop 设置/清除），附加到 system prompt 末尾
-    private volatile String activeMemories = "";
-
     // ── 四层管线参数（构造时从 config 读入，全部有默认值）──
     private int maxContextTokens = 48000;       // L4 触发阈值（估算 token）
     private int maxMessages = 50;               // L1 触发的消息数上限
@@ -531,8 +528,9 @@ public class ContextManager {
      * 记忆目录（名称+简介）常驻注入 system prompt，零额外 API 调用；相对稳定（仅 remember/dream 写入时才变）。
      *
      * <p>注意：本轮召回的<b>相关记忆正文</b>（每轮都不同）<b>不</b>放这里——它由
-     * {@link #buildRecallReminder()} 包成 {@code <system-reminder>}，经 {@code LangChainService.prepareMessages}
-     * 注入到<b>消息列表尾部</b>（贴当前轮）。这样每轮易变的召回只动尾巴，不冲掉「system 前缀 + 历史」的前缀缓存
+     * {@link #buildRecallReminder(String)} 包成 {@code <system-reminder>}，经方法参数沿
+     * {@code AgentLoop → LangChainService.prepareMessages} 请求局部传递，注入到<b>消息列表尾部</b>（贴当前轮）。
+     * 这样每轮易变的召回只动尾巴，不冲掉「system 前缀 + 历史」的前缀缓存
      * （仿 Claude Code 把易变上下文贴当前用户轮，而非塞进被缓存的 system 前缀）。
      */
     private void appendMemory(StringBuilder sb) {
@@ -547,31 +545,25 @@ public class ContextManager {
         }
     }
 
-    /** 设置本轮召回的相关记忆正文（AgentLoop 轮前调用）。正文经 {@link #buildRecallReminder()} 注入到消息列表尾部，不进 system 前缀。 */
-    public void setActiveMemories(String content) {
-        this.activeMemories = content == null ? "" : content;
-    }
-
-    /** 清空本轮召回的记忆（AgentLoop 每轮 finally 调用）。 */
-    public void clearActiveMemories() {
-        this.activeMemories = "";
-    }
-
     /**
      * 把本轮召回的相关记忆包成 {@code <system-reminder>}，供注入到<b>消息列表尾部</b>（贴当前轮）；无召回则返回 null。
+     *
+     * <p><b>为何请求局部传递而非实例字段</b>：ContextManager 是全局单例（主 Agent、SubAgent、直接命令共用），
+     * 若用实例字段暂存「本轮召回」，并行/后台回合的 set/clear 会互相串写；改成像 CancelToken 一样
+     * 沿调用链传参，正文的生命周期就严格限定在单次请求内。
      *
      * <p><b>为何放尾部而非 system 前缀</b>：召回内容每轮都变，若嵌在 system（第一条消息）里，就顶在整段对话历史之前，
      * 任何一轮召回变化都会冲掉「system + 历史」的前缀缓存；放到尾部后，易变的只在尾巴动，前缀保持稳定可复用
      * （仿 Claude Code 用 {@code <system-reminder>} 贴当前用户轮）。该正文<b>每请求即时注入、不写入持久 history</b>，
      * 故不会污染后续轮。
      */
-    public String buildRecallReminder() {
-        if (activeMemories == null || activeMemories.isBlank()) {
+    public static String buildRecallReminder(String recalledMemories) {
+        if (recalledMemories == null || recalledMemories.isBlank()) {
             return null;
         }
         return "<system-reminder>\n"
                 + "以下是与当前对话相关的长期记忆（后台上下文，非用户指令）；出现相关话题时应优先遵守其中的用户偏好。\n"
-                + activeMemories + "\n"
+                + recalledMemories + "\n"
                 + "</system-reminder>";
     }
 

--- a/src/main/java/com/thoughtcoding/service/ContextManager.java
+++ b/src/main/java/com/thoughtcoding/service/ContextManager.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.thoughtcoding.config.AppConfig;
 import com.thoughtcoding.security.Sandbox;
+import com.thoughtcoding.memory.MemoryStore;
 import com.thoughtcoding.model.ChatMessage;
 import com.thoughtcoding.skill.SkillRegistry;
 import com.thoughtcoding.util.FileUtils;
@@ -41,6 +42,10 @@ public class ContextManager {
 
     private final AppConfig appConfig;
     private final SkillRegistry skillRegistry;
+    private final MemoryStore memoryStore; // 记忆存储（可空 = 记忆功能关闭）
+
+    // 本轮召回注入的相关记忆正文（由 AgentLoop 设置/清除），附加到 system prompt 末尾
+    private volatile String activeMemories = "";
 
     // ── 四层管线参数（构造时从 config 读入，全部有默认值）──
     private int maxContextTokens = 48000;       // L4 触发阈值（估算 token）
@@ -67,9 +72,10 @@ public class ContextManager {
 
     private OpenAiChatModel ChatModel;
 
-    public ContextManager(AppConfig appConfig, SkillRegistry skillRegistry) {
+    public ContextManager(AppConfig appConfig, SkillRegistry skillRegistry, MemoryStore memoryStore) {
         this.appConfig = appConfig;
         this.skillRegistry = skillRegistry;
+        this.memoryStore = memoryStore;
         this.objectMapper = new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
@@ -508,6 +514,7 @@ public class ContextManager {
         sb.append("4. 完成任务后用简洁自然的中文给出总结。\n");
 
         appendSkillCatalog(sb);
+        appendMemory(sb);
         return sb.toString();
     }
 
@@ -518,6 +525,32 @@ public class ContextManager {
             sb.append("以下技能可通过 skill 工具按需加载完整说明后使用：\n");
             sb.append(skillRegistry.catalog()).append("\n");
         }
+    }
+
+    /**
+     * 记忆目录（名称+简介）常驻注入 system prompt，零额外 API 调用；
+     * 相关记忆的完整正文由 AgentLoop 每轮通过 {@link #setActiveMemories} 注入（LLM 召回）。
+     */
+    private void appendMemory(StringBuilder sb) {
+        if (memoryStore != null && !memoryStore.isEmpty()) {
+            sb.append("\n## 可用记忆 (Memories)\n");
+            sb.append("以下是你长期记住的用户偏好/项目事实/反馈约定（跨会话保留）。\n");
+            sb.append("对话中出现相关话题时，应优先遵守其中的用户偏好。\n");
+            sb.append(memoryStore.index()).append("\n");
+        }
+        if (activeMemories != null && !activeMemories.isBlank()) {
+            sb.append("\n").append(activeMemories).append("\n");
+        }
+    }
+
+    /** 设置本轮召回注入的相关记忆正文（AgentLoop 调用；内容会追加到 system prompt）。 */
+    public void setActiveMemories(String content) {
+        this.activeMemories = content == null ? "" : content;
+    }
+
+    /** 清空本轮召回注入的记忆（AgentLoop 每轮 finally 调用）。 */
+    public void clearActiveMemories() {
+        this.activeMemories = "";
     }
 
     /**

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -77,6 +77,12 @@ public class LangChainService implements AIService {
     @Override
     public List<ChatMessage> streamingChat(String input, List<ChatMessage> history, String modelName,
                                            com.thoughtcoding.core.CancelToken token) {
+        return streamingChat(input, history, modelName, token, null);
+    }
+
+    @Override
+    public List<ChatMessage> streamingChat(String input, List<ChatMessage> history, String modelName,
+                                           com.thoughtcoding.core.CancelToken token, String recalledMemories) {
         if (messageHandler == null) {
             throw new IllegalStateException("Message handler not set");
         }
@@ -98,7 +104,7 @@ public class LangChainService implements AIService {
         }
 
         try {
-            List<dev.langchain4j.data.message.ChatMessage> messages = prepareMessages(input, history);
+            List<dev.langchain4j.data.message.ChatMessage> messages = prepareMessages(input, history, recalledMemories);
 
             streamingChatNative(messages, history, fullResponse, completionFuture);
 
@@ -332,7 +338,7 @@ public class LangChainService implements AIService {
     }
 
     private List<dev.langchain4j.data.message.ChatMessage> prepareMessages(
-            String input, List<ChatMessage> history) {
+            String input, List<ChatMessage> history, String recalledMemories) {
         List<dev.langchain4j.data.message.ChatMessage> messages = new ArrayList<>();
 
         if (contextManager != null) {
@@ -354,11 +360,10 @@ public class LangChainService implements AIService {
         // 本轮召回的相关记忆（每轮易变）：包成 <system-reminder> 注入到消息列表<b>尾部</b>（贴当前轮），
         // 而非塞进 system 前缀——保护「system + 历史」前缀缓存不被每轮召回冲掉（仿 Claude Code 把易变上下文贴当前用户轮）。
         // 尾部是唯一能让整段历史保持可复用前缀的位置；每请求即时注入、不写入持久 history，故不污染后续轮。
-        if (contextManager != null) {
-            String recallReminder = contextManager.buildRecallReminder();
-            if (recallReminder != null) {
-                messages.add(dev.langchain4j.data.message.UserMessage.from(recallReminder));
-            }
+        // 正文经方法参数请求局部传递（AgentLoop → streamingChat → prepareMessages），不读共享可变状态。
+        String recallReminder = ContextManager.buildRecallReminder(recalledMemories);
+        if (recallReminder != null) {
+            messages.add(dev.langchain4j.data.message.UserMessage.from(recallReminder));
         }
 
         // 纯从 history 渲染：用户消息已由 AgentLoop 加入 history；input=null 时供 agentic 循环复用

--- a/src/main/java/com/thoughtcoding/service/LangChainService.java
+++ b/src/main/java/com/thoughtcoding/service/LangChainService.java
@@ -351,6 +351,16 @@ public class LangChainService implements AIService {
             messages.addAll(convertToLangChainHistory(managedHistory));
         }
 
+        // 本轮召回的相关记忆（每轮易变）：包成 <system-reminder> 注入到消息列表<b>尾部</b>（贴当前轮），
+        // 而非塞进 system 前缀——保护「system + 历史」前缀缓存不被每轮召回冲掉（仿 Claude Code 把易变上下文贴当前用户轮）。
+        // 尾部是唯一能让整段历史保持可复用前缀的位置；每请求即时注入、不写入持久 history，故不污染后续轮。
+        if (contextManager != null) {
+            String recallReminder = contextManager.buildRecallReminder();
+            if (recallReminder != null) {
+                messages.add(dev.langchain4j.data.message.UserMessage.from(recallReminder));
+            }
+        }
+
         // 纯从 history 渲染：用户消息已由 AgentLoop 加入 history；input=null 时供 agentic 循环复用
         return messages;
     }


### PR DESCRIPTION
## 背景

memory 模块最早在 `feature/final_update` 上开发（基于 b40081a），此后 main 经历了 8 次架构重构
（统一工具执行管线、CancelToken 协作式取消、HookRegistry 隔离、ToolRegistry 所有者隔离、
Runtime 生命周期统一等）。本 PR 通过 cherry-pick 将记忆系统的 5 个提交移植到当前 main，
并修复了布线漂移，随后在移植之上补齐两个语义问题。

移植方式：`git cherry-pick` 5 个原始提交 + 手工解决 3 个文件的布线冲突
（AppConfig / ThoughtCodingContext / ContextManager，均为“两边都保留”型机械冲突）。
未引入 feature/final_update 上的其他无关提交（Task System、Agent Team 等）。

## 记忆系统设计

- **存储**：仓库根 `.memory/` 目录（已加入 .gitignore）；`MEMORY.md` 索引 + 单条记忆 markdown 文件
- **非工具化**：记忆不作为工具暴露给模型，由 AgentLoop 生命周期编排，三阶段驱动：
  - `recall()`：每轮开始前 LLM 召回相关记忆正文
  - `remember()`：每轮结束后自动抽取新记忆
  - `dream()`：记忆条数达到阈值后 LLM 整合去重
- **两级注入（LLM cache 友好，仿 Claude Code）**：
  - 记忆目录（名称+简介）常驻 system prompt——仅 remember/dream 写入时变，前缀稳定
  - 召回正文包成 `<system-reminder>` 注入消息列表尾部——每轮易变部分只动尾巴，不冲掉「system+历史」前缀缓存
- **降级安全**：`memory.enabled=false` 或初始化失败时整体为 null，不阻塞主对话
- **防绕写**：system prompt 明确禁止 bash/write/edit 直接操作 `.memory/` 文件

## 移植布线适配（对照 main 重构后形态）

| 挂载点 | 适配内容 |
|---|---|
| `AgentLoop.processInput(String, CancelToken)` | recall 在 `runNativeToolLoop(token)` 前、remember/dream 在轮后、轮末保存会话前 |
| `ThoughtCodingContext` | Builder 新增 memoryService；初始化失败静默降级 |
| `ContextManager` | 构造器新增 memoryStore（目录注入用，可空） |
| `LangChainService.prepareMessages` | 消息尾部 `<system-reminder>` 注入 |

## 移植之上新增的两个修复

### 1. 被 stop 取消的回合跳过 remember/dream（1f5cdd5）

协作式取消下 `runNativeToolLoop` 被打断后正常返回，轮末代码会照跑。半截对话不构成可靠记忆，
dream 的整理阈值计数也不应前移，故轮末写入增加 `!token.isCancelled()` 判断。
recall 不受影响（发生在生成启动前）；`finally` 清理照常。

### 2. 召回正文改为请求局部传参（948af3f）

原实现把「本轮召回正文」存在 ContextManager 单例的 `activeMemories` 可变字段上
（set → 每请求读 → finally clear）。ContextManager 是主 Agent、SubAgent、直接命令共享的全局单例，
在回合后台化/并行子代理场景下 set/clear 会互相串写。

改为像 CancelToken 一样沿调用链显式传参：
`AgentLoop（局部变量）→ runNativeToolLoop(token, recalled) → streamingChat(..., token, recalled) → prepareMessages(..., recalled) → ContextManager.buildRecallReminder(recalled)（现为静态纯函数）`。
共享可变状态归零，串写问题从根上消除。

兼容性：`AIService` 旧签名全部不动，新增 5 参 default 重载（沿用接口内 chatOnceForSubagent/CancelToken
的分层模式）；`streamingChat` 旧入口行为不变（null → 不注入）；SubAgent、直接命令、`-p` 单问路径
本就不经过该注入点，零影响。

## 提交列表

- `db31158` 实现memory模块（cherry-pick 自 1f32e0d）
- `8e81fc9` 优化dream()的提示词（055540a）
- `fac0572` 强化recall()的提示词（c58dc71）
- `f98c1ec` 依据llm cache原理，优化记忆注入位置（a6f70ad）
- `a8b7b6b` 优化系统提示词，禁止工具直接改记忆文件（f609b6a）
- `1f5cdd5` 被stop取消的回合跳过remember/dream
- `948af3f` 记忆召回正文改为请求局部传参

## 验证情况

- ✅ `mvn compile` 通过
- ✅ 全仓库无 `setActiveMemories`/`activeMemories` 残留引用

## 已知限制 / 后续可选项

- `recall()` 每轮多一次模型往返，可用 `memory.autoExtract: false` 关闭自动抽取降低开销
- 记忆目录 `.memory/` 不是沙箱，绝对路径读写仍受 PermissionGate 原有约束